### PR TITLE
feature: 게시글 생성,읽기,수정,삭제 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,8 +2,11 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
+import { BoardModule } from './board/board.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(), UserModule, AuthModule],
+  imports: [TypeOrmModule.forRoot(), UserModule, AuthModule, BoardModule],
+  providers: [],
+  controllers: [],
 })
 export class AppModule {}

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  UseGuards,
+  Post,
+  Body,
+  Get,
+  Param,
+  Patch,
+  Delete
+} from '@nestjs/common';
+import { CreateBoard } from 'src/dto/board/create-board.dto';
+import { BoardService } from './board.service';
+import { GetUser } from 'src/custom-decorator/get-user.decorator';
+import { User } from 'src/entity/user.entity';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { UpdateBoard } from 'src/dto/board/update-board.dto';
+
+@Controller('board')
+@UseGuards(JwtAuthGuard)
+export class BoardController {
+  constructor(private readonly boardService: BoardService) {}
+
+  @Post('')
+  async createBoard(@GetUser() user: User, @Body() data: CreateBoard) {
+    const result = await this.boardService.createBoard(user, data);
+
+    // 에러 관련해선 임의로 작성. 추후 리팩토링 할 때 error & 성공 response 보낼 때 통일 된 형식으로 보낼 수 있도록 논의 필요
+    return { statusCode: 201, message: 'posting success', result: result };
+  }
+
+  @Get('/:id')
+  async readBoard(@GetUser() user: User, @Param() params: any) {
+    const result = await this.boardService.readBoard(user, params.id);
+
+    return { statusCode: 200, message: 'read post', result: result };
+  }
+
+  @Patch('/:id')
+  async updateBoard(
+    @GetUser() user: User,
+    @Body() data: UpdateBoard,
+    @Param() params: any,
+  ) {
+    const result = await this.boardService.updateBoard(user, data, params.id);
+
+    return { statusCode: 200, message: 'update post', result: result };
+  }
+
+  @Delete('/:id')
+  async deleteBoard(@GetUser() user: User, @Param() params: any) {
+    const reuslt = await this.boardService.deleteBoard(user, params.id);
+
+    return { statusCode: 200, message: 'delete post', result: reuslt};
+  }
+}

--- a/src/board/board.module.ts
+++ b/src/board/board.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BoardRepository } from 'src/repository/board.repository';
+import { BoardController } from './board.controller';
+import { BoardService } from './board.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([BoardRepository])],
+  controllers: [BoardController],
+  providers: [BoardService]
+})
+export class BoardModule {}

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { CreateBoard } from 'src/dto/board/create-board.dto';
+import { UpdateBoard } from 'src/dto/board/update-board.dto';
+import { User } from 'src/entity/user.entity';
+import { BoardRepository } from 'src/repository/board.repository';
+
+@Injectable()
+export class BoardService {
+  constructor(private boardRepository: BoardRepository) {}
+
+  async createBoard(user:User, data: CreateBoard, ) {
+
+    const board = await this.boardRepository.createBaord(user, data);
+
+    return { board, is_writer: true }
+  }
+
+  async readBoard(user:User, post_id: number) {
+    const board = await this.boardRepository.selectOneBoard(post_id);
+
+    let is_writer: boolean = false;
+
+    if(user.id == board[0].userid)
+      is_writer = true;
+      
+    return { board, is_writer }
+  }
+
+  async updateBoard(user: User, data: UpdateBoard, post_id: number) {
+
+    const board = await this.boardRepository.updateBoard(user, data, post_id);
+
+    return { board, is_writer: true }
+  }
+
+  async deleteBoard(user: User, post_id: number) {
+
+    return await this.boardRepository.deleteBoard(user, post_id);
+  }
+}

--- a/src/custom-decorator/get-user.decorator.ts
+++ b/src/custom-decorator/get-user.decorator.ts
@@ -1,0 +1,7 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { User } from "src/entity/user.entity";
+
+export const GetUser = createParamDecorator((data, ctx: ExecutionContext): User => {
+    const req = ctx.switchToHttp().getRequest();
+    return req.user;
+})

--- a/src/dto/board/create-board.dto.ts
+++ b/src/dto/board/create-board.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsNumber, IsNotEmpty, Max, Min } from "class-validator";
+
+export class CreateBoard {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @IsNotEmpty()
+  @IsNumber()
+  status: number
+
+  @IsString()
+  thumbnail: string;
+}

--- a/src/dto/board/update-board.dto.ts
+++ b/src/dto/board/update-board.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateBoard } from "./create-board.dto";
+
+export class UpdateBoard extends PartialType(CreateBoard){
+}

--- a/src/entity/board.entity.ts
+++ b/src/entity/board.entity.ts
@@ -1,0 +1,43 @@
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity({ name: 'board'})
+export class Board extends BaseEntity{
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({length: 200})
+  title: string;
+
+  @Column({length: 3000})
+  content: string;
+
+  @Column({type: "tinyint"})
+  status: number
+
+  @Column({length: 3000})
+  thumbnail: string;
+
+  @Column({default: 0})
+  views: number;
+
+  @Column({default: 0})
+  likes: number;
+
+  @CreateDateColumn()
+  create_at: Date;
+
+  @UpdateDateColumn()
+  update_at: Date;
+
+  @ManyToOne(type => User, user => user.id)
+  user: User
+}

--- a/src/entity/user.entity.ts
+++ b/src/entity/user.entity.ts
@@ -4,7 +4,9 @@ import {
   Entity,
   PrimaryGeneratedColumn,
   Unique,
+  OneToMany
 } from 'typeorm';
+import { Board } from './board.entity';
 
 @Entity({ name: 'user' })
 @Unique(['email'])
@@ -42,4 +44,7 @@ export class User extends BaseEntity {
 
   @Column({ default: false })
   update_alert: boolean;
+
+  @OneToMany(type => Board, board => board.user)
+  boards: Board[]
 }

--- a/src/repository/board.repository.ts
+++ b/src/repository/board.repository.ts
@@ -1,0 +1,95 @@
+import { BadRequestException, InternalServerErrorException, NotFoundException } from "@nestjs/common/exceptions";
+import { CreateBoard } from "src/dto/board/create-board.dto";
+import { UpdateBoard } from "src/dto/board/update-board.dto";
+import { Board } from "src/entity/board.entity";
+import { User } from "src/entity/user.entity";
+import { EntityRepository, Repository } from "typeorm";
+
+@EntityRepository(Board)
+export class BoardRepository extends Repository<Board> {
+
+  async selectOneBoard(post_id: number) {
+
+      const board = await this.query(
+        `SELECT id, status, views, likes, create_at, update_at, userid, title, content, thumbnail 
+         FROM board
+         WHERE id = ?`
+        , [post_id]);
+
+      if(board.length <= 0)
+        throw new NotFoundException(`해당 게시글을 찾을 수 없습니다.`);
+      
+      return board;
+  }
+  
+  async createBaord(user:User, data: CreateBoard) {
+    const board = this.create({
+      title: data.title,
+      content: data.content,
+      status: data.status,
+      thumbnail: data.thumbnail,
+      user: user
+    });
+
+    try {
+      await this.save(board);
+
+      const result = await this.selectOneBoard(board.id);
+
+      return result;
+    } catch(err) {
+      if(err.errno)
+        throw new BadRequestException(`posting create failed`);
+      
+      throw new InternalServerErrorException();
+    }
+  }
+
+  async updateBoard(user: User, data: UpdateBoard, post_id: number) {
+
+    await this.selectOneBoard(post_id);
+
+    const board = this.createQueryBuilder()
+    .update(Board)
+    .set({
+      title: data.title,
+      content: data.content,
+      status: data.status,
+      thumbnail: data.thumbnail,
+    })
+    .where(`id = :post_id AND userid = :user_id`, { post_id: post_id, user_id: user.id});
+
+    try {
+      await board.execute();
+
+      return await this.selectOneBoard(post_id);
+
+    } catch (err) {
+      if(err.errno)
+        throw new BadRequestException(`posting update failed`);  
+      
+        throw new InternalServerErrorException();
+    }
+
+  }
+
+  async deleteBoard(user: User, post_id: number) {
+
+    await this.selectOneBoard(post_id);
+
+    const board = this.createQueryBuilder()
+    .delete()
+    .from(Board)
+    .where(`id = :post_id AND userid = :user_id`, { post_id: post_id, user_id: user.id });
+
+    try {
+      return await board.execute();
+    } catch (err) {
+      if(err.errno)
+        throw new BadRequestException(`posting update failed`);
+
+      throw new InternalServerErrorException();
+    }
+  }
+  
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 게시글 생성,읽기,수정,삭제 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

1. @GetUser 라는 커스텀 데코레이터 추가. 사용자 정보가 필요한 작업을 할 때 request에서 사용자의 정보를 손쉽게
가지고 올 수 있도록 구현

2. 게시글 생성,읽기,수정,삭제 기능 구현 jwt토큰을 통한 사용자 인증 후 작업. UseGuards 데코레이터를 통해 해당
기능을 간편하게 사용가능

response로 값을 보내 줄 때 is_writer를 같이 보내주어 true일 경우 해당 게시글의 수정/삭제 권한이 부여될 수 있도록 기능 구현.

<br />

## :: 기타 질문 및 특이 사항

- 엔티티에 외래키 설정을 하고 난 뒤, findOne() 메서드로 값을 가져올 경우 외래키의 값(user_id)은 제외되어 가지고 와져 불가피하게 직접 쿼리를 작성해야 했음.
- 에러처리 관련을 controller에서 처리하고 싶었으나 불가피하게 repository에서 작업을 함. 에러처리 관련은 추후 리팩토링 과정을 거치면서 수정이 필요함.
- 또한, response 메시지의 통일이 필요해 보임.
