### PR TITLE
feature: 게시글 목록 & 상세페이지 관련 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { AuthModule } from './auth/auth.module';
 import { PostModule } from './post/post.module';
 import { TagModule } from './tag/tag.module';
 import { CommentModule } from './comment/comment.module';
+import { InsideModule } from './inside/inside.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { CommentModule } from './comment/comment.module';
     PostModule,
     TagModule,
     CommentModule,
+    InsideModule,
   ],
   providers: [],
   controllers: [],

--- a/src/comment/comment.module.ts
+++ b/src/comment/comment.module.ts
@@ -6,6 +6,7 @@ import { CommentService } from './comment.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([CommentRepository])],
+  exports: [TypeOrmModule, CommentService],
   controllers: [CommentController],
   providers: [CommentService],
 })

--- a/src/entity/post.entity.ts
+++ b/src/entity/post.entity.ts
@@ -33,6 +33,9 @@ export class Post extends BaseEntity {
   @Column({ default: 0 })
   likes: number;
 
+  @Column({ default: 0 })
+  comment_count: number;
+
   @CreateDateColumn()
   create_at: Date;
 

--- a/src/inside/inside.controller.ts
+++ b/src/inside/inside.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { InsideService } from './inside.service';
+
+@Controller('inside')
+export class InsideController {
+  constructor(private readonly insideService: InsideService) {}
+
+  @Get('/:user_id')
+  async getInsidePage(
+    @Param('user_id') user_id: number,
+    @Query('tag_id') tag_id: number,
+  ) {
+    const result = await this.insideService.getInsidePage(user_id, tag_id);
+
+    return { statusCode: 200, posts: result.posts, tags: result.tags };
+  }
+
+  @Get('/:user_id/:post_id')
+  async getPostDetail(
+    @Param('user_id') user_id: number,
+    @Param('post_id') post_id: number,
+  ) {
+    const result = await this.insideService.getPostDetail(user_id, post_id);
+
+    return {
+      statusCode: 200,
+      post: result.post.post,
+      next_post: result.post.next_post,
+      pre_post: result.post.pre_post,
+      comments: result.comments,
+    };
+  }
+
+  @Get('/:user_id/series')
+  async getSeries(@Param('user_id') user_id: number) {}
+
+  @Get('/:user_id/about')
+  async getAbout(@Param('user_id') user_id: number) {}
+}

--- a/src/inside/inside.module.ts
+++ b/src/inside/inside.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CommentModule } from 'src/comment/comment.module';
+import { PostModule } from 'src/post/post.module';
+import { TagModule } from 'src/tag/tag.module';
+import { InsideController } from './inside.controller';
+import { InsideService } from './inside.service';
+
+@Module({
+  imports: [PostModule, CommentModule, TagModule],
+  controllers: [InsideController],
+  providers: [InsideService],
+})
+export class InsideModule {}

--- a/src/inside/inside.service.ts
+++ b/src/inside/inside.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { CommentService } from 'src/comment/comment.service';
+import { PostService } from 'src/post/post.service';
+import { TagService } from 'src/tag/tag.service';
+
+@Injectable()
+export class InsideService {
+  constructor(
+    private postService: PostService,
+    private commentService: CommentService,
+    private tagService: TagService,
+  ) {}
+
+  async getInsidePage(user_id: number, tag_id: number) {
+    const posts = await this.postService.selectPostList(user_id, tag_id);
+    const tags = await this.tagService.selectTagListByUserId(user_id);
+
+    return { posts, tags };
+  }
+
+  async getPostDetail(user_id: number, post_id: number) {
+    const post = await this.postService.selectPostOne(user_id, post_id);
+    const comments = await this.commentService.selectCommentList(
+      post_id,
+      user_id,
+    );
+
+    return {
+      post,
+      comments,
+    };
+  }
+
+  async getSeries(user_id: number) {
+    // 시리즈 들고오는 것
+  }
+
+  async getAbout(user_id: number) {
+    // 소개 들고오는 것
+  }
+}

--- a/src/post/post.module.ts
+++ b/src/post/post.module.ts
@@ -7,6 +7,7 @@ import { PostService } from './post.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([PostRepository]), TagModule],
+  exports: [TypeOrmModule, PostService],
   controllers: [PostController],
   providers: [PostService],
 })

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -32,15 +32,22 @@ export class PostService {
     return { post, create_post };
   }
 
-  // async readPost(user: User, post_id: number) {
-  //   const post = await this.postRepository.selectPostOne(post_id);
+  async selectPostOne(user_id: number, post_id: number) {
+    const post = await this.postRepository.selectPostOne(user_id, post_id);
 
-  //   let is_writer: boolean = false;
+    for (let i = 0; i < post.length; i++) {
+      if (post[i].tags) {
+        const to_json = JSON.parse(post[i].tags);
 
-  //   if (user.id == post[0].user_id) is_writer = true;
+        post[i].tags = to_json;
+      }
+    }
 
-  //   return { post, is_writer };
-  // }
+    const next_post = await this.postRepository.selectNextPost(post_id);
+    const pre_post = await this.postRepository.selectPrePost(post_id);
+
+    return { post, next_post, pre_post };
+  }
 
   async updatePost(
     user: User,
@@ -73,30 +80,21 @@ export class PostService {
     return { post, delete_post };
   }
 
-  // velogController 따로 구성하여 해당 기능 분리할 예정.
-  //   async selectPostList(
-  //     user: User,
-  //     user_id: number,
-  //     status: number,
-  //     tag: string,
-  //   ) {
-  //     // user에서 받아온 id랑 param으로 넘어온 user_id 비교해서 일치 = is_writer:true 하면 임시 글을 제외한 나머지 글 다 보여주기.
-  //     // 일치하지 않으면 is_writer: false  공개글 목록만 보여주기
-  //     // 태그 선택하면 태그id랑 일치한 것 보여주기
-  //     /*
-  //     -> 필요한 것
-  //     제목
-  //     login_id
-  //     작성일
-  //     공개여부
-  //     태크
-  //     이전포스트
-  //     다음포스트
-  //     */
-  //     let is_writer: boolean = false;
-  //     if(user_id == user.id)
-  //       is_writer = true;
+  async selectPostList(user_id: number, tag_id: number) {
+    const posts = await this.postRepository.selectPostList(
+      user_id,
+      false,
+      tag_id,
+    );
 
-  //     return await this.postRepository.selectPostList(is_writer, status, tag);
-  //   }
+    for (let i = 0; i < posts.length; i++) {
+      if (posts[i].tags) {
+        const to_json = JSON.parse(posts[i].tags);
+
+        posts[i].tags = to_json;
+      }
+    }
+
+    return posts;
+  }
 }

--- a/src/repository/comment.repository.ts
+++ b/src/repository/comment.repository.ts
@@ -91,7 +91,7 @@ export class CommentRepository extends Repository<Comment> {
       comments.create_at,
       comments.update_at,
       nc.nested_comments,
-      IF(user.id = ?, 'true', 'false') AS comments_is_writer
+      IF(user.id = ?, 1, 0) AS comments_is_writer
       FROM comments
       LEFT JOIN post ON post.id = comments.post_id
       LEFT JOIN user ON user.id = comments.user_id

--- a/src/repository/post-tag.repository.ts
+++ b/src/repository/post-tag.repository.ts
@@ -32,4 +32,21 @@ export class PostTagRepository extends Repository<PostTag> {
       console.log(err);
     }
   }
+
+  async selectTagListByUserId(user_id: number) {
+    const tags = await this.query(
+      `SELECT
+    COUNT(post_tag.tag_id) AS post_count,
+    tag.id AS tag_id,
+    tag.name
+    FROM post_tag
+    LEFT JOIN tag ON tag.id = post_tag.tag_id
+    LEFT JOIN post ON post.id = post_tag.post_id
+    WHERE post.user_id = ?
+    GROUP BY post_tag.tag_id`,
+      [user_id],
+    );
+
+    return tags;
+  }
 }

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -48,4 +48,10 @@ export class TagService {
   async deletePostTag(post_id: number) {
     await this.postTagRepository.deletePostTag(post_id);
   }
+
+  async selectTagListByUserId(user_id: number) {
+    const tags = await this.postTagRepository.selectTagListByUserId(user_id);
+
+    return tags;
+  }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 각 사용자의 velog 페이지에 보여지는 태그목록과 게시글 목록 그리고 게시글 상세페이지 관련 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

1. 게시글 목록과 태그 목록을 한 번에 불러오도록 기능 구현. 목록에서 태그 id값을 queryString으로 받아 해당 태그와 일치하는 게시글 목록 불러오기 기능도 같이 구현.
2. 게시글 상세페이지 읽어오는 기능 구현. 이전/다음 포스트와 댓글 목록도 같이 불러오도록 구현.

<br />

## :: 기타 질문 및 특이 사항

- 게시글 상세페이지 읽어올 때 시리즈 기능도 불러오도록 추가적으로 구현이 필요.
- 태그가 적용되지 않은 게시글의 경우 null 값이 아닌 {tag_id:null, tag_name:null} 형식으로 조회가 되어, 태그가 포함되지 않은 경우엔 null을 반환하도록 쿼리를 작성하기 위하여 WITH을 사용하였음.
