### PR TITLE
fix: 댓글 생성/수정/삭제 기능 수정

### DIFF
--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -7,8 +7,6 @@ import {
   Patch,
   Delete,
   BadRequestException,
-  Get,
-  NotFoundException,
 } from '@nestjs/common';
 import { CommentDto } from 'src/dto/comment/comment.dto';
 import { CommentService } from './comment.service';
@@ -37,19 +35,24 @@ export class CommentController {
 
     return {
       statusCode: 201,
-      message: 'comment create success',
+      post: result.post.post,
+      next_post: result.post.next_post,
+      pre_post: result.post.pre_post,
+      comments: result.comments,
     };
   }
 
-  @Patch('/:comment_id')
+  @Patch('/:post_id/:comment_id')
   async updateComment(
     @Body() data: CommentDto,
     @Param('comment_id') comment_id: number,
+    @Param('post_id') post_id: number,
     @GetUser() user: User,
   ) {
     const result = await this.commentService.updateComment(
       data,
       comment_id,
+      post_id,
       user.id,
     );
 
@@ -62,36 +65,23 @@ export class CommentController {
     };
   }
 
-  @Delete('/:comment_id')
+  @Delete('/:post_id/:comment_id')
   async deleteComment(
     @Param('comment_id') comment_id: number,
+    @Param('post_id') post_id: number,
     @GetUser() user: User,
   ) {
-    const result = await this.commentService.deleteComment(comment_id, user.id);
+    const result = await this.commentService.deleteComment(
+      comment_id,
+      post_id,
+      user.id,
+    );
 
     if (result == 0) throw new BadRequestException('comment delete failed');
 
     return {
       statusCode: 200,
       message: 'comment delete success',
-      result: result,
-    };
-  }
-
-  @Get('/:post_id')
-  async selectCommentList(
-    @Param('post_id') post_id: number,
-    @GetUser() user: User,
-  ) {
-    const result = await this.commentService.selectCommentList(
-      post_id,
-      user.id,
-    );
-
-    if (result == 0) throw new NotFoundException(`댓글이 존재하지 않습니다.`);
-
-    return {
-      statusCode: 200,
       result: result,
     };
   }

--- a/src/comment/comment.module.ts
+++ b/src/comment/comment.module.ts
@@ -1,11 +1,16 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { PostModule } from 'src/post/post.module';
 import { CommentRepository } from 'src/repository/comment.repository';
+import { PostRepository } from 'src/repository/post.repository';
 import { CommentController } from './comment.controller';
 import { CommentService } from './comment.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CommentRepository])],
+  imports: [
+    TypeOrmModule.forFeature([CommentRepository, PostRepository]),
+    PostModule,
+  ],
   exports: [TypeOrmModule, CommentService],
   controllers: [CommentController],
   providers: [CommentService],

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -1,34 +1,16 @@
 import { Injectable } from '@nestjs/common';
 import { CommentDto } from 'src/dto/comment/comment.dto';
+import { PostService } from 'src/post/post.service';
 import { CommentRepository } from 'src/repository/comment.repository';
+import { PostRepository } from 'src/repository/post.repository';
 
 @Injectable()
 export class CommentService {
-  constructor(private commentRepository: CommentRepository) {}
-
-  async createComment(data: CommentDto, post_id: number, user_id: number) {
-    if (data.depth == 1 && !data.parent_id) return 0;
-
-    const result = await this.commentRepository.createComment(
-      data,
-      post_id,
-      user_id,
-    );
-
-    return result;
-  }
-
-  async updateComment(data: CommentDto, comment_id: number, user_id: number) {
-    return await this.commentRepository.updateComment(
-      data,
-      comment_id,
-      user_id,
-    );
-  }
-
-  async deleteComment(comment_id: number, user_id: number) {
-    return await this.commentRepository.deleteComment(comment_id, user_id);
-  }
+  constructor(
+    private commentRepository: CommentRepository,
+    private postRepository: PostRepository,
+    private postService: PostService,
+  ) {}
 
   async selectCommentList(post_id: number, user_id: number) {
     let result = await this.commentRepository.selectCommentList(
@@ -45,5 +27,60 @@ export class CommentService {
     }
 
     return result;
+  }
+
+  async createComment(data: CommentDto, post_id: number, user_id: number) {
+    if (data.depth == 1 && !data.parent_id) return 0;
+
+    const result = await this.commentRepository.createComment(
+      data,
+      post_id,
+      user_id,
+    );
+
+    if (result == 0) return 0;
+
+    await this.postRepository.updateCommentCount(post_id);
+
+    const comments = await this.selectCommentList(post_id, user_id);
+    const post = await this.postService.selectPostOne(user_id, post_id);
+
+    return { post, comments };
+  }
+
+  async updateComment(
+    data: CommentDto,
+    comment_id: number,
+    post_id: number,
+    user_id: number,
+  ) {
+    const result = await this.commentRepository.updateComment(
+      data,
+      comment_id,
+      user_id,
+    );
+
+    if (result == 0) return 0;
+
+    const comments = await this.selectCommentList(post_id, user_id);
+    const post = await this.postService.selectPostOne(user_id, post_id);
+
+    return { post, comments };
+  }
+
+  async deleteComment(comment_id: number, post_id: number, user_id: number) {
+    const result = await this.commentRepository.deleteComment(
+      comment_id,
+      user_id,
+    );
+
+    if (result == 0) return 0;
+
+    await this.postRepository.updateCommentCount(post_id);
+
+    const comments = await this.selectCommentList(post_id, user_id);
+    const post = await this.postService.selectPostOne(user_id, post_id);
+
+    return { post, comments };
   }
 }

--- a/src/repository/comment.repository.ts
+++ b/src/repository/comment.repository.ts
@@ -96,7 +96,8 @@ export class CommentRepository extends Repository<Comment> {
       LEFT JOIN post ON post.id = comments.post_id
       LEFT JOIN user ON user.id = comments.user_id
       LEFT JOIN nested_comments nc ON nc.comment_id = comments.id
-      WHERE post.id = ?`,
+      WHERE post.id = ?
+      ORDER BY comments.id DESC`,
       [user_id, user_id, post_id],
     );
 

--- a/src/repository/post.repository.ts
+++ b/src/repository/post.repository.ts
@@ -159,7 +159,9 @@ export class PostRepository extends Repository<Post> {
       parameter.push(tag_id);
     }
 
-    query = query + and_status + and_tag;
+    let order_by = ` ORDER BY post.id DESC`;
+
+    query = query + and_status + and_tag + order_by;
 
     const posts = await this.query(query, parameter);
 
@@ -190,5 +192,12 @@ export class PostRepository extends Repository<Post> {
     );
 
     return pre_post;
+  }
+
+  async updateCommentCount(post_id: number) {
+    await this.query(
+      `UPDATE post SET comment_count = (SELECT COUNT(*) FROM comments WHERE post_id = ?) WHERE id = ?`,
+      [post_id, post_id],
+    );
   }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [x] 기능 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 댓글 생성/수정/삭제 기능 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

1. 댓글 생성/수정/삭제 시에 게시글 상세페이지 내용 불러오도록 기능 수정(게시글 상세 페이지 내용, 이전/다음 포스트 정보, 댓글 목록)
2. 댓글 생성/삭제 시에 post 테이블의 comment_count가 update 됨.
3. 댓글 읽기 기능은 inside controller에서 처리 됨.

<br />

## :: 기타 질문 및 특이 사항

- post 테이블의 comment_count update 관련은 추후 트리거 사용해볼 예정
