### PR TITLE
feature: 메인 페이지 게시글 조회 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { TagModule } from './tag/tag.module';
 import { CommentModule } from './comment/comment.module';
 import { InsideModule } from './inside/inside.module';
 import { SeriesModule } from './series/series.module';
+import { MainModule } from './main/main.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { SeriesModule } from './series/series.module';
     CommentModule,
     InsideModule,
     SeriesModule,
+    MainModule,
   ],
   providers: [],
   controllers: [],

--- a/src/main/main.controller.ts
+++ b/src/main/main.controller.ts
@@ -1,0 +1,25 @@
+import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import { MainService } from './main.service';
+
+@Controller('main')
+export class MainController {
+  constructor(private readonly mainService: MainService) {}
+
+  @Get('')
+  async getMainPosts(
+    @Query('type') type: string,
+    @Query('period') period: string,
+  ) {
+    const result = await this.mainService.getMainPosts(type, period);
+
+    if (result == 0)
+      throw new BadRequestException(
+        `트랜딩을 조회할 땐 period이 필수 값 입니다.`,
+      );
+
+    return {
+      statusCode: 200,
+      post: result,
+    };
+  }
+}

--- a/src/main/main.module.ts
+++ b/src/main/main.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PostModule } from 'src/post/post.module';
+import { MainController } from './main.controller';
+import { MainService } from './main.service';
+
+@Module({
+  imports: [PostModule],
+  controllers: [MainController],
+  providers: [MainService],
+})
+export class MainModule {}

--- a/src/main/main.service.ts
+++ b/src/main/main.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { PostService } from 'src/post/post.service';
+
+@Injectable()
+export class MainService {
+  constructor(private postService: PostService) {}
+
+  async getMainPosts(type: string, period: string) {
+    const posts = await this.postService.selectPostListForMain(type, period);
+
+    return posts;
+  }
+}

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -128,4 +128,12 @@ export class PostService {
   async getSeriesList(user_id: number) {
     return this.seriesService.selectSeriesList(user_id);
   }
+
+  async selectPostListForMain(type: string, period: string) {
+    if (type == 'TREND' && !period) return 0;
+
+    const posts = await this.postRepository.selectPostListForMain(type, period);
+
+    return posts;
+  }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 메인 페이지 게시글 조회 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

1. 트렌딩 조회 수 + 좋아요를 더하여 합계가 많이 나온 순으로 정렬이 되도록 하였음.
(단, 조회 수나 좋아요가 0일 경우엔 제외 됨)
트렌딩으로 조회할 땐 period(오늘-TODAY, 이번 주-WEEK, 이번 달-MONTH, 올해-YEAR)가 필수로 지정되어야 함

2. 최신 최근 작성된 게시글 기준으로 정렬되도록 하였음.

<br />

## :: 기타 질문 및 특이 사항
- 게시글 페이징 관련 기능 구현이 필요함.
