### PR TITLE
feature : 최근 읽은 게시글 기능 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { TagModule } from './tag/tag.module';
 import { CommentModule } from './comment/comment.module';
 import { InsideModule } from './inside/inside.module';
 import { SeriesModule } from './series/series.module';
+import { ListsModule } from './lists/lists.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { SeriesModule } from './series/series.module';
     CommentModule,
     InsideModule,
     SeriesModule,
+    ListsModule,
   ],
   providers: [],
   controllers: [],

--- a/src/custom-decorator/validate-token.decorator.ts
+++ b/src/custom-decorator/validate-token.decorator.ts
@@ -1,0 +1,16 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+import { User } from 'src/entity/user.entity';
+
+export const ValidateToken = createParamDecorator(
+  (data, ctx: ExecutionContext): User => {
+    const bearerToken = ctx.switchToHttp().getRequest()['rawHeaders'][1];
+    if (bearerToken.includes('Bearer')) {
+      const token = bearerToken.replace('Bearer ', '');
+      const user = jwt.verify(token, process.env.SECRET_KEY)['user'];
+
+      return user;
+    }
+    return null;
+  },
+);

--- a/src/entity/post-read-log.entity.ts
+++ b/src/entity/post-read-log.entity.ts
@@ -1,0 +1,28 @@
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Post } from './post.entity';
+import { User } from './user.entity';
+
+@Entity({ name: 'post_read_log' })
+export class PostReadLog extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne((type) => User)
+  @JoinColumn({ name: 'user_id' })
+  user: number;
+
+  @ManyToOne((type) => Post)
+  @JoinColumn({ name: 'post_id' })
+  post: number;
+
+  @CreateDateColumn()
+  create_at: Date;
+}

--- a/src/inside/inside.controller.ts
+++ b/src/inside/inside.controller.ts
@@ -1,4 +1,17 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Headers,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { GetUser } from 'src/custom-decorator/get-user.decorator';
+import { ValidateToken } from 'src/custom-decorator/validate-token.decorator';
+import { User } from 'src/entity/user.entity';
 import { InsideService } from './inside.service';
 
 @Controller('inside')
@@ -19,8 +32,13 @@ export class InsideController {
   async getPostDetail(
     @Param('user_id') user_id: number,
     @Param('post_id') post_id: number,
+    @ValidateToken() user?: User,
   ) {
-    const result = await this.insideService.getPostDetail(user_id, post_id);
+    const result = await this.insideService.getPostDetail(
+      user_id,
+      post_id,
+      user,
+    );
 
     return {
       statusCode: 200,

--- a/src/inside/inside.module.ts
+++ b/src/inside/inside.module.ts
@@ -1,13 +1,25 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommentModule } from 'src/comment/comment.module';
 import { PostModule } from 'src/post/post.module';
+import { PostReadLogRepository } from 'src/repository/post-read-log.repository';
 import { SeriesModule } from 'src/series/series.module';
 import { TagModule } from 'src/tag/tag.module';
 import { InsideController } from './inside.controller';
 import { InsideService } from './inside.service';
 
 @Module({
-  imports: [PostModule, CommentModule, TagModule, SeriesModule],
+  imports: [
+    PostModule,
+    CommentModule,
+    TagModule,
+    SeriesModule,
+    TypeOrmModule.forFeature([PostReadLogRepository]),
+    JwtModule.register({
+      secret: process.env.SECRET_KEY,
+    }),
+  ],
   controllers: [InsideController],
   providers: [InsideService],
 })

--- a/src/inside/inside.service.ts
+++ b/src/inside/inside.service.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { CommentService } from 'src/comment/comment.service';
 import { PostService } from 'src/post/post.service';
+import { PostReadLogRepository } from 'src/repository/post-read-log.repository';
 import { SeriesService } from 'src/series/series.service';
 import { TagService } from 'src/tag/tag.service';
+import { JwtService } from '@nestjs/jwt';
+import { User } from 'src/entity/user.entity';
 
 @Injectable()
 export class InsideService {
@@ -11,6 +14,8 @@ export class InsideService {
     private commentService: CommentService,
     private tagService: TagService,
     private seriesService: SeriesService,
+    private postReadLogRepository: PostReadLogRepository,
+    private readonly jwtService: JwtService,
   ) {}
 
   async getInsidePage(user_id: number, tag_id: number) {
@@ -20,13 +25,24 @@ export class InsideService {
     return { posts, tags };
   }
 
-  async getPostDetail(user_id: number, post_id: number) {
+  async getPostDetail(user_id: number, post_id: number, user?: User) {
     const post = await this.postService.selectPostOne(user_id, post_id);
     const comments = await this.commentService.selectCommentList(
       post_id,
       user_id,
     );
     const series = await this.seriesService.selectPostSeriesList(post_id);
+
+    if (user && user_id !== user['sub']) {
+      const exist = await this.postReadLogRepository.getReadLogBypostId(
+        user['sub'],
+        post_id,
+      );
+
+      if (exist[0].exist === '0' && post.post.user_id !== user['sub']) {
+        await this.postReadLogRepository.createReadLog(user['sub'], post_id);
+      }
+    }
 
     return {
       post,

--- a/src/lists/lists.controller.ts
+++ b/src/lists/lists.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { GetUser } from 'src/custom-decorator/get-user.decorator';
+import { User } from 'src/entity/user.entity';
+import { ListsService } from './lists.service';
+
+@Controller('lists')
+export class ListsController {
+  constructor(private readonly listsService: ListsService) {}
+
+  @Get('/read')
+  @UsePipes(ValidationPipe)
+  @UseGuards(JwtAuthGuard)
+  async getReadList(@GetUser() user: User) {
+    const data = await this.listsService.getReadLog(user.id);
+    return data;
+  }
+
+  @Patch('/read/:post_id')
+  @UseGuards(JwtAuthGuard)
+  async deleteReadList(
+    @GetUser() user: User,
+    @Param('post_id') post_id: number,
+  ) {
+    const data = await this.listsService.deleteReadList(user.id, post_id);
+    return data;
+  }
+}

--- a/src/lists/lists.module.ts
+++ b/src/lists/lists.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PostReadLogRepository } from 'src/repository/post-read-log.repository';
+import { ListsController } from './lists.controller';
+import { ListsService } from './lists.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PostReadLogRepository])],
+  controllers: [ListsController],
+  providers: [ListsService],
+})
+export class ListsModule {}

--- a/src/lists/lists.service.ts
+++ b/src/lists/lists.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PostReadLogRepository } from 'src/repository/post-read-log.repository';
+
+@Injectable()
+export class ListsService {
+  constructor(private postReadLogRepository: PostReadLogRepository) {}
+  async getReadLog(user_id: number) {
+    const data = await this.postReadLogRepository.getReadLog(user_id);
+    for (let i = 0; i < data.length; i++) {
+      data[i].ReadLog = JSON.parse(data[i].ReadLog);
+    }
+    return data[0];
+  }
+
+  async deleteReadList(user_id: number, post_id: number) {
+    await this.postReadLogRepository.deleteReadList(user_id, post_id);
+    return await this.getReadLog(user_id);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,8 @@ async function bootstrap() {
     }),
   );
 
+  app.enableCors();
+
   await app.listen(process.env.SERVER_POST);
 }
 

--- a/src/repository/post-read-log.repository.ts
+++ b/src/repository/post-read-log.repository.ts
@@ -1,0 +1,59 @@
+import { PostReadLog } from 'src/entity/post-read-log.entity';
+import { EntityRepository, Repository } from 'typeorm';
+
+@EntityRepository(PostReadLog)
+export class PostReadLogRepository extends Repository<PostReadLog> {
+  async getReadLogBypostId(user_id: number, post_id: number) {
+    return await this.query(
+      `
+        SELECT EXISTS (SELECT * FROM post_read_log WHERE user_id = ? AND post_id = ?) AS exist;
+      `,
+      [user_id, post_id],
+    );
+  }
+
+  async createReadLog(user_id: number, post_id: number) {
+    const readLog = this.create({
+      user: user_id,
+      post: post_id,
+    });
+
+    await this.save(readLog);
+  }
+
+  async getReadLog(user_id: number) {
+    return await this.query(
+      `
+      SELECT 
+      JSON_ARRAYAGG(
+        JSON_OBJECT(
+          'post_id', post.id, 
+          'post_title', post.title, 
+          'post_thumbnail', post.thumbnail, 
+          'post_content', post.content, 
+          'post_likes', post.likes, 
+          'post_comment_count', post.comment_count,
+          'post_create_at', DATE_FORMAT(post.create_at, "%Y년 %m월 %d일"),
+          'user_id', user.id,
+          'user_name', user.name,
+          'user_profile_image', user.profile_image
+        )
+      ) as ReadLog
+      FROM post_read_log
+      LEFT JOIN post ON post_read_log.post_id = post.id
+      LEFT JOIN user ON post.user_id = user.id
+      WHERE post_read_log.user_id = ?
+      ORDER BY post_read_log.create_at DESC;
+      `,
+      [user_id],
+    );
+  }
+
+  async deleteReadList(user_id: number, post_id: number) {
+    await this.createQueryBuilder()
+      .delete()
+      .from(PostReadLog)
+      .where(`user_id = :user_id AND post_id = :post_id`, { user_id, post_id })
+      .execute();
+  }
+}


### PR DESCRIPTION
게시글 상세 내용을 읽을 때 post_read_log 테이블에 읽은 유저의 id,
게시글의 id 를 insert

게시글을 읽는 기능은 비로그인, 로그인 상관 없이 모두 가능해야하며 로그를
기록하는 경우는 로그인을 한 경우에만 가능해야함

이를 구현하기 위해 ValidateToken이라는 커스텀 데코레이터를 만들어서
토큰이 있으면 User을 반환, 토큰이 없으면 null을 반환

User이 존재할 때만 log 기록하는 기능 실행

최근 읽은 게시글 기록을 삭제하는 경우 토큰과 post_id를 받아와 해당하는
데이터를 삭제 후 남은 데이터를 모두 반환(프론트에서 재랜더링을
해야하므로 바뀐 데이터를 모두 반환)

## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 최근 읽은 게시글 로그 남기기 및 삭제

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

게시글을 읽을 때 로그인 한 유저가 어떤 게시글을 읽은지 DB에 넣어야함
이때 @UseGuards를 사용하면 토큰이 없는 경우 에러가 발생함
- 비로그인 유저도 게시글은 읽을 수 있어야하므로 UseGuards 사용 불가

해결방안
- ValidateToken이라는 커스템 데코레이터를 생성
  - Request에서 Bearer Token을 가져오고 토큰이 있으면 verify하여 User 반환
  - 토큰이 없으면 null 반환
- 서비스단에서 user 값이 있을 때만 log 기록하는 함수 실행

최근 읽은 게시글 로그 보기
- 해당 유저가 읽은 게시글 데이터만 조회하여 반환

로그 삭제
- 삭제하려는 post_id를 Param으로 받아와서 delete 후 남은 데이터를 반환
<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
