### PR TITLE
feature : 게시글 좋아요 및 취소, 내역 불러오기

### DIFF
--- a/src/entity/post-like.entity.ts
+++ b/src/entity/post-like.entity.ts
@@ -1,0 +1,27 @@
+import {
+  BaseEntity,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Post } from './post.entity';
+import { User } from './user.entity';
+
+@Entity({ name: 'post_like' })
+export class PostLike extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne((type) => User)
+  @JoinColumn({ name: 'user_id' })
+  user: number;
+
+  @ManyToOne((type) => Post)
+  @JoinColumn({ name: 'post_id' })
+  post: number;
+
+  @CreateDateColumn()
+  create_at: Date;
+}

--- a/src/entity/post-read-log.entity.ts
+++ b/src/entity/post-read-log.entity.ts
@@ -1,6 +1,5 @@
 import {
   BaseEntity,
-  Column,
   CreateDateColumn,
   Entity,
   JoinColumn,

--- a/src/inside/inside.controller.ts
+++ b/src/inside/inside.controller.ts
@@ -1,18 +1,20 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
-import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
-import { GetUser } from 'src/custom-decorator/get-user.decorator';
 import { ValidateToken } from 'src/custom-decorator/validate-token.decorator';
 import { User } from 'src/entity/user.entity';
 import { AboutBlogDto } from 'src/dto/user/about-blog.dto';
 import { InsideService } from './inside.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { GetUser } from 'src/custom-decorator/get-user.decorator';
 
 @Controller('inside')
 export class InsideController {
@@ -71,5 +73,19 @@ export class InsideController {
     );
 
     return { statusCode: 200, about: result };
+  }
+
+  @Post('/:post_id/like')
+  @UseGuards(JwtAuthGuard)
+  async likePost(@Param('post_id') post_id: number, @GetUser() user: User) {
+    await this.insideService.likePost(user.id, post_id);
+    return { statusCode: 200 };
+  }
+
+  @Delete('/:post_id/like')
+  @UseGuards(JwtAuthGuard)
+  async unlikePost(@Param('post_id') post_id: number, @GetUser() user: User) {
+    await this.insideService.unlikePost(user.id, post_id);
+    return { statusCode: 204 };
   }
 }

--- a/src/inside/inside.module.ts
+++ b/src/inside/inside.module.ts
@@ -3,6 +3,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommentModule } from 'src/comment/comment.module';
 import { PostModule } from 'src/post/post.module';
+import { PostLikeRepository } from 'src/repository/post-like.repository';
 import { PostReadLogRepository } from 'src/repository/post-read-log.repository';
 import { SeriesModule } from 'src/series/series.module';
 import { TagModule } from 'src/tag/tag.module';
@@ -17,7 +18,7 @@ import { InsideService } from './inside.service';
     TagModule,
     SeriesModule,
     UserModule,
-    TypeOrmModule.forFeature([PostReadLogRepository]),
+    TypeOrmModule.forFeature([PostReadLogRepository, PostLikeRepository]),
     JwtModule.register({
       secret: process.env.SECRET_KEY,
     }),

--- a/src/inside/inside.service.ts
+++ b/src/inside/inside.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { CommentService } from 'src/comment/comment.service';
 import { PostService } from 'src/post/post.service';
 import { PostReadLogRepository } from 'src/repository/post-read-log.repository';
@@ -7,6 +7,7 @@ import { TagService } from 'src/tag/tag.service';
 import { JwtService } from '@nestjs/jwt';
 import { User } from 'src/entity/user.entity';
 import { UserService } from 'src/user/user.service';
+import { PostLikeRepository } from 'src/repository/post-like.repository';
 
 @Injectable()
 export class InsideService {
@@ -18,6 +19,7 @@ export class InsideService {
     private postReadLogRepository: PostReadLogRepository,
     private readonly jwtService: JwtService,
     private userService: UserService,
+    private postLikeRepository: PostLikeRepository,
   ) {}
 
   async getInsidePage(user_id: number, tag_id: number) {
@@ -65,5 +67,13 @@ export class InsideService {
     await this.userService.updateAboutBlog(user_id, about_blog);
 
     return await this.userService.selectAboutBlog(user_id);
+  }
+
+  async likePost(user_id: number, post_id: number) {
+    await this.postLikeRepository.likePost(user_id, post_id);
+  }
+
+  async unlikePost(user_id: number, post_id: number) {
+    await this.postLikeRepository.unlikePost(user_id, post_id);
   }
 }

--- a/src/lists/lists.controller.ts
+++ b/src/lists/lists.controller.ts
@@ -1,6 +1,5 @@
 import {
   Controller,
-  Delete,
   Get,
   Param,
   Patch,
@@ -32,6 +31,13 @@ export class ListsController {
     @Param('post_id') post_id: number,
   ) {
     const data = await this.listsService.deleteReadList(user.id, post_id);
+    return data;
+  }
+
+  @Get('/like')
+  @UseGuards(JwtAuthGuard)
+  async getLikedList(@GetUser() user: User) {
+    const data = await this.listsService.getLikedList(user.id);
     return data;
   }
 }

--- a/src/lists/lists.module.ts
+++ b/src/lists/lists.module.ts
@@ -1,11 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { PostLikeRepository } from 'src/repository/post-like.repository';
 import { PostReadLogRepository } from 'src/repository/post-read-log.repository';
 import { ListsController } from './lists.controller';
 import { ListsService } from './lists.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PostReadLogRepository])],
+  imports: [
+    TypeOrmModule.forFeature([PostReadLogRepository, PostLikeRepository]),
+  ],
   controllers: [ListsController],
   providers: [ListsService],
 })

--- a/src/lists/lists.service.ts
+++ b/src/lists/lists.service.ts
@@ -1,9 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { PostLikeRepository } from 'src/repository/post-like.repository';
 import { PostReadLogRepository } from 'src/repository/post-read-log.repository';
 
 @Injectable()
 export class ListsService {
-  constructor(private postReadLogRepository: PostReadLogRepository) {}
+  constructor(
+    private postReadLogRepository: PostReadLogRepository,
+    private postLikeRepository: PostLikeRepository,
+  ) {}
   async getReadLog(user_id: number) {
     const data = await this.postReadLogRepository.getReadLog(user_id);
     for (let i = 0; i < data.length; i++) {
@@ -15,5 +19,13 @@ export class ListsService {
   async deleteReadList(user_id: number, post_id: number) {
     await this.postReadLogRepository.deleteReadList(user_id, post_id);
     return await this.getReadLog(user_id);
+  }
+
+  async getLikedList(user_id: number) {
+    const data = await this.postLikeRepository.getLikedList(user_id);
+    for (let i = 0; i < data.length; i++) {
+      data[i].LIKED_POST = JSON.parse(data[i].LIKED_POST);
+    }
+    return data[0];
   }
 }

--- a/src/repository/post-like.repository.ts
+++ b/src/repository/post-like.repository.ts
@@ -1,0 +1,44 @@
+import { PostLike } from 'src/entity/post-like.entity';
+import { EntityRepository, Repository } from 'typeorm';
+
+@EntityRepository(PostLike)
+export class PostLikeRepository extends Repository<PostLike> {
+  async likePost(user_id: number, post_id: number) {
+    const likePost = this.create({ user: user_id, post: post_id });
+    await this.save(likePost);
+  }
+
+  async unlikePost(user_id: number, post_id: number) {
+    await this.createQueryBuilder()
+      .delete()
+      .where(`user = :user_id AND post_id = :post_id`, { user_id, post_id })
+      .execute();
+  }
+
+  async getLikedList(user_id: number) {
+    return await this.query(
+      `
+        SELECT
+          JSON_ARRAYAGG(
+            JSON_OBJECT(
+              'post_id', post.id,
+              'title', post.title,
+              'thumbnail', post.thumbnail,
+              'content', post.content,
+              'create_at', DATE_FORMAT(post.create_at, "%Y년 %m월 %d일"),
+              'post_likes', post.likes, 
+              'post_comment_count', post.comment_count,
+              'user_id', user.id,
+              'user_name', user.name,
+              'user_profile_image', user.profile_image
+            )
+          ) AS LIKED_POST
+        FROM post_like
+        LEFT JOIN post ON post_like.post_id = post.id
+        LEFT JOIN user ON post_like.user_id = user.id
+        WHERE post_like.user_id = ?;
+      `,
+      [user_id],
+    );
+  }
+}

--- a/src/repository/post-like.repository.ts
+++ b/src/repository/post-like.repository.ts
@@ -15,6 +15,10 @@ export class PostLikeRepository extends Repository<PostLike> {
       .execute();
   }
 
+  async getLikedPostOne(user_id: number, post_id: number) {
+    return await this.findOne({ user: user_id, post: post_id });
+  }
+
   async getLikedList(user_id: number) {
     return await this.query(
       `

--- a/src/repository/post.repository.ts
+++ b/src/repository/post.repository.ts
@@ -201,6 +201,13 @@ export class PostRepository extends Repository<Post> {
     );
   }
 
+  async updateLikeCount(post_id: number) {
+    await this.query(
+      `UPDATE post SET likes = (SELECT COUNT(*) FROM post_like WHERE post_id = ?) WHERE id = ?`,
+      [post_id, post_id],
+    );
+  }
+
   async selectPostListForMain(type: string, period: string) {
     let query = `SELECT 
    user.id AS user_id,


### PR DESCRIPTION
게시글 좋아요
- post_id를 param으로 가져와서 user_id와 post_id를 DB에 삽입

좋아요 취소
- post_id를 param으로 가져와서 user_id와 post_id에 해당하는 데이터가 DB에 있으면 삭제

좋아요한 게시글 목록 보기
- user 테이블과 post 테이블, post_like 테이블을 join하여 해당하는 데이터를 가져옴

## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 게시글 좋아요 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

게시글 좋아요
- param으로 post_id를 받아와 user_id와 함께 post_like 테이블에 삽입

게시글 좋아요 취소
- param으로 post_id를 받아와 해당하는 데이터가 DB에 있으면 삭제

좋아요한 게시글 목록 가져오기
- 토큰으로 찾아온 user_id를 사용해 post_like 테이블에 user_id에 해당하는 데이터를 모두 user, post 테이블과 join하여 반환
<br />

## :: 기타 질문 및 특이 사항

