### PR TITLE
refactor: 시리즈 생성/조회/수정/삭제

### DIFF
--- a/src/dto/series/select-series-posts.dto.ts
+++ b/src/dto/series/select-series-posts.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { SeriesSort } from 'src/series/series.model';
+
+export class SelectSereisPostsDto {
+  @IsEnum(SeriesSort)
+  sort: SeriesSort;
+}

--- a/src/entity/series.entity.ts
+++ b/src/entity/series.entity.ts
@@ -22,6 +22,9 @@ export class Series {
   @Column()
   series_name: string;
 
+  @Column({ nullable: true })
+  thumbnail: string;
+
   @Column({ default: 0 })
   post_count: number;
 

--- a/src/lolog/lolog.controller.ts
+++ b/src/lolog/lolog.controller.ts
@@ -35,44 +35,6 @@ export class LologController {
     return { statusCode: 200, about: result };
   }
 
-  @Get('/:user_id/series/:series_id')
-  async getSeriesDetail(
-    @Param('user_id') user_id: number,
-    @Param('series_id') series_id: number,
-    @Query('sort') sort: string,
-    @Query() pagination: PaginationDto,
-  ) {
-    const result = await this.lologService.getSeriesDetail(
-      user_id,
-      series_id,
-      sort,
-      pagination,
-    );
-
-    return { statusCode: 200, series: result };
-  }
-
-  @Patch('/:user_id/series/:series_id')
-  async editSeries(
-    @Param('user_id') user_id: number,
-    @Param('series_id') series_id: number,
-    @Body('sort') sort,
-  ) {
-    await this.lologService.editSeries(series_id, sort);
-
-    return { statusCode: 200, message: 'update seires success' };
-  }
-
-  @Delete('/:user_id/series/:series_id')
-  async deleteSeries(
-    @Param('user_id') user_id: number,
-    @Param('series_id') series_id: number,
-  ) {
-    await this.lologService.deleteSeries(series_id, user_id);
-
-    return { statusCode: 200, message: 'delete seires success' };
-  }
-
   @Get('/:user_id')
   async getInsidePage(
     @Param('user_id') user_id: number,

--- a/src/lolog/lolog.service.ts
+++ b/src/lolog/lolog.service.ts
@@ -74,30 +74,6 @@ export class LologService {
     return series;
   }
 
-  async getSeriesDetail(
-    user_id: number,
-    series_id: number,
-    sort: string,
-    pagination: PaginationDto,
-  ) {
-    const series = await this.seriesService.selectSeriesDetail(
-      user_id,
-      series_id,
-      sort,
-      pagination,
-    );
-
-    return series;
-  }
-
-  async editSeries(series_id: number, sort) {
-    await this.seriesService.updatePostSeriesSort(series_id, sort);
-  }
-
-  async deleteSeries(seires_id: number, user_id: number) {
-    await this.seriesService.deleteSeries(seires_id);
-  }
-
   async getAboutBlog(user_id: number) {
     return await this.userService.selectAboutBlog(user_id);
   }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -17,7 +17,6 @@ import { GetUser } from 'src/custom-decorator/get-user.decorator';
 import { User } from 'src/entity/user.entity';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { UpdatePostDto } from 'src/dto/post/update-post.dto';
-import { CreateSeriesDto } from 'src/dto/series/create-series.dto';
 import { PaginationDto } from 'src/dto/pagination.dto';
 
 @Controller('posts')
@@ -107,22 +106,5 @@ export class PostController {
     }
 
     return { statusCode: 200, message: 'post delete success' };
-  }
-
-  @Post('/series')
-  async createSeries(@GetUser() user: User, @Body() data: CreateSeriesDto) {
-    const result = await this.postService.createSeries(
-      user.id,
-      data.series_name,
-    );
-
-    return { statusCode: 200, series: result };
-  }
-
-  @Get('/series')
-  async getSeriesList(@GetUser() user: User) {
-    const result = await this.postService.getSeriesList(user.id);
-
-    return { statusCode: 200, series: result };
   }
 }

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -5,9 +5,7 @@ import { User } from 'src/entity/user.entity';
 import { PostRepository } from 'src/repository/post.repository';
 import { SeriesService } from 'src/series/series.service';
 import { TagService } from 'src/tag/tag.service';
-import { getImageURL, deleteImageFile } from 'src/lib/multerOptions';
 import { PaginationDto } from 'src/dto/pagination.dto';
-import { CommentService } from 'src/comment/comment.service';
 
 /**
  * @todo 게시글 삭제 시에 tag 테이블의 post_count 관련 기능은 추후 구현할 예정..
@@ -96,7 +94,7 @@ export class PostService {
 
     if (!data.series_id) {
       // 시리즈에서 제외 시켰을 경우 post_series 테이블에 삭제되어야 함.
-      await this.seriesService.deletePostSeries(post_id, user.id, 0);
+      await this.seriesService.deletePostSeries(post_id, null);
     } else {
       await this.seriesService.createPostSeries(
         post_id,
@@ -142,14 +140,6 @@ export class PostService {
     }
 
     return posts;
-  }
-
-  async createSeries(user_id: number, series_name: string) {
-    return this.seriesService.createSeries(user_id, series_name);
-  }
-
-  async getSeriesList(user_id: number) {
-    return this.seriesService.selectSeriesList(user_id);
   }
 
   async selectPostListForMain(type: string, period: string) {

--- a/src/repository/post-series.repository.ts
+++ b/src/repository/post-series.repository.ts
@@ -3,6 +3,17 @@ import { EntityRepository, Repository } from 'typeorm';
 
 @EntityRepository(PostSeries)
 export class PostSeriesRepository extends Repository<PostSeries> {
+  async updatePostSeriesSort(series_id: number, post_id: number, sort: number) {
+    await this.createQueryBuilder()
+      .update(PostSeries)
+      .set({
+        sort: sort,
+      })
+      .where('series_id = :series_id', { series_id: series_id })
+      .andWhere('post_id = :post_id', { post_id: post_id })
+      .execute();
+  }
+
   async selectPostSeriesSort(series_id: number) {
     const sort = await this.findOne(series_id);
 
@@ -27,13 +38,10 @@ export class PostSeriesRepository extends Repository<PostSeries> {
   async deletePostSeries(post_id: number, series_id: number) {
     const post_series = this.createQueryBuilder().delete().from(PostSeries);
 
-    if (post_id > 0) {
-      post_series.where(`post_id = :post_id`, { post_id: post_id });
-    }
+    if (post_id) post_series.where(`post_id = :post_id`, { post_id: post_id });
 
-    if (series_id > 0) {
+    if (series_id)
       post_series.where('series_id = :series_id', { series_id: series_id });
-    }
 
     await post_series.execute();
   }
@@ -52,16 +60,5 @@ export class PostSeriesRepository extends Repository<PostSeries> {
     );
 
     return post_series;
-  }
-
-  async updatePostSeriesSort(series_id: number, post_id: number, sort: number) {
-    await this.createQueryBuilder()
-      .update(PostSeries)
-      .set({
-        sort: sort,
-      })
-      .where('series_id = :series_id', { series_id: series_id })
-      .andWhere('post_id = :post_id', { post_id: post_id })
-      .execute();
   }
 }

--- a/src/repository/series.repository.ts
+++ b/src/repository/series.repository.ts
@@ -52,7 +52,7 @@ export class SeriesRepository extends Repository<Series> {
         'series.user_id AS user_id',
         'post.id AS post_id',
         'post_series.sort',
-        'post.thumbnail',
+        'series.thumbnail',
         'post.title',
         'post.content',
         'post.create_at',

--- a/src/repository/series.repository.ts
+++ b/src/repository/series.repository.ts
@@ -1,8 +1,28 @@
+import { SelectSereisPostsDto } from 'src/dto/series/select-series-posts.dto';
 import { Series } from 'src/entity/series.entity';
+import { SeriesSort } from 'src/series/series.model';
 import { EntityRepository, Repository } from 'typeorm';
 
 @EntityRepository(Series)
 export class SeriesRepository extends Repository<Series> {
+  async selectSeriesList(user_id: number) {
+    const series = this.createQueryBuilder('series')
+      .leftJoin('series.post_series', 'post_series')
+      .leftJoin('post', 'post', 'post_series.post_id = post.id')
+      .where('series.user_id = :user_id', { user_id: user_id })
+      .select([
+        'series.id AS series_id',
+        'series.thumbnail',
+        'series.series_name',
+        'series.post_count',
+        'series.create_at',
+      ])
+      .groupBy('series.id')
+      .orderBy('series.create_at', 'ASC');
+
+    return await series.getRawMany();
+  }
+
   async createSeries(user_id: number, series_name: string) {
     const series = this.create({
       series_name: series_name,
@@ -17,41 +37,12 @@ export class SeriesRepository extends Repository<Series> {
     }
   }
 
-  async updateSeriesPostCount(user_id: number) {
-    await this.query(
-      `UPDATE series SET post_count = (SELECT COUNT(*) FROM post_series WHERE series_id = series.id)
-      WHERE user_id = ?`,
-      [user_id],
-    );
-  }
-
-  async selectSeriesList(user_id: number) {
-    const series = this.createQueryBuilder('series')
-      .leftJoin('series.post_series', 'post_series')
-      .leftJoin('post', 'post', 'post_series.post_id = post.id')
-      .where('series.user_id = :user_id', { user_id: user_id })
-      .andWhere('post_series.sort = 1')
-      .select([
-        'series.id AS series_id',
-        'post.thumbnail',
-        'series.series_name',
-        'series.post_count',
-        'series.create_at',
-      ])
-      .groupBy('series.id')
-      .orderBy('series.create_at', 'ASC');
-
-    return await series.getRawMany();
-  }
-
-  async selectSeriesDetail(
+  async SelectSereisPosts(
     user_id: number,
     series_id: number,
-    sort: string,
-    offset: number,
-    limit: number,
+    sort: SeriesSort,
   ) {
-    const series = this.createQueryBuilder('series')
+    const series_posts = this.createQueryBuilder('series')
       .leftJoin('series.post_series', 'post_series')
       .leftJoin('post', 'post', 'post_series.post_id = post.id')
       .where('series.user_id = :user_id', { user_id: user_id })
@@ -68,18 +59,15 @@ export class SeriesRepository extends Repository<Series> {
       ]);
 
     switch (sort) {
-      case 'asc':
-        series.orderBy('post_series.sort', 'ASC');
+      case SeriesSort.ASC:
+        series_posts.orderBy('post_series.sort', 'ASC');
         break;
-      case 'desc':
-        series.orderBy('post_series.sort', 'DESC');
+      case SeriesSort.DESC:
+        series_posts.orderBy('post_series.sort', 'DESC');
         break;
     }
 
-    series.offset(offset * limit - limit);
-    series.limit(limit);
-
-    return await series.getRawMany();
+    return await series_posts.getRawMany();
   }
 
   async deleteSeries(seires_id: number) {

--- a/src/series/series.controller.ts
+++ b/src/series/series.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  UseGuards,
+  Post,
+  Body,
+  BadRequestException,
+  Get,
+  Param,
+  Query,
+  Patch,
+  Delete,
+} from '@nestjs/common';
+import { SeriesService } from './series.service';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { GetUser } from 'src/custom-decorator/get-user.decorator';
+import { User } from 'src/entity/user.entity';
+import { CreateSeriesDto } from 'src/dto/series/create-series.dto';
+import { SelectSereisPostsDto } from 'src/dto/series/select-series-posts.dto';
+
+@Controller('series')
+@UseGuards(JwtAuthGuard)
+export class SeriesController {
+  constructor(private readonly seriesService: SeriesService) {}
+
+  @Post('')
+  async createSeries(@GetUser() user: User, @Body() data: CreateSeriesDto) {
+    const result = await this.seriesService.createSeries(
+      user.id,
+      data.series_name,
+    );
+
+    if (result == 0) throw new BadRequestException(`create series failed`);
+
+    return { statusCode: 200, series: result };
+  }
+
+  @Get('')
+  async selectSeriesList(@GetUser() user: User) {
+    const result = await this.seriesService.selectSeriesList(user.id);
+
+    return { statusCode: 200, series: result };
+  }
+
+  @Get('/:id')
+  async SelectSereisPosts(
+    @GetUser() user: User,
+    @Param('id') series_id: number,
+    @Query() sort: SelectSereisPostsDto,
+  ) {
+    const result = await this.seriesService.SelectSereisPosts(
+      user.id,
+      series_id,
+      sort,
+    );
+
+    return { statusCode: 200, series: result };
+  }
+
+  @Patch('/:id')
+  async updatePostSeriesSort(
+    @Param('id') series_id: number,
+    @Body('sort') sort,
+  ) {
+    await this.seriesService.updatePostSeriesSort(series_id, sort);
+
+    return { statusCode: 200, message: 'seires update success' };
+  }
+
+  @Delete('/:id')
+  async deleteSeries(@Param('id') series_id: number) {
+    await this.seriesService.deleteSeries(series_id);
+
+    return { statusCode: 200, message: 'seires delete success' };
+  }
+}

--- a/src/series/series.model.ts
+++ b/src/series/series.model.ts
@@ -1,0 +1,4 @@
+export enum SeriesSort {
+  ASC = 'asc',
+  DESC = 'desc',
+}

--- a/src/series/series.module.ts
+++ b/src/series/series.module.ts
@@ -3,10 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostSeriesRepository } from 'src/repository/post-series.repository';
 import { SeriesRepository } from 'src/repository/series.repository';
 import { SeriesService } from './series.service';
+import { SeriesController } from './series.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([SeriesRepository, PostSeriesRepository])],
   exports: [TypeOrmModule, SeriesService],
   providers: [SeriesService],
+  controllers: [SeriesController],
 })
 export class SeriesModule {}

--- a/src/series/series.service.ts
+++ b/src/series/series.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { PaginationDto } from 'src/dto/pagination.dto';
+import { SelectSereisPostsDto } from 'src/dto/series/select-series-posts.dto';
 import { PostSeriesRepository } from 'src/repository/post-series.repository';
 import { SeriesRepository } from 'src/repository/series.repository';
 
@@ -9,6 +9,63 @@ export class SeriesService {
     private seriesRepository: SeriesRepository,
     private postSeriesRepository: PostSeriesRepository,
   ) {}
+
+  async selectSeriesList(user_id: number) {
+    const series = await this.seriesRepository.selectSeriesList(user_id);
+
+    return series;
+  }
+
+  async createSeries(user_id: number, series_name: string) {
+    const result = await this.seriesRepository.createSeries(
+      user_id,
+      series_name,
+    );
+
+    if (result == 0) return 0;
+
+    return this.selectSeriesList(user_id);
+  }
+
+  async SelectSereisPosts(
+    user_id: number,
+    series_id: number,
+    sort: SelectSereisPostsDto,
+  ) {
+    const seires_posts = await this.seriesRepository.SelectSereisPosts(
+      user_id,
+      series_id,
+      sort.sort,
+    );
+
+    if (seires_posts[0].user_id == user_id) {
+      seires_posts.push({ is_owner: 1 });
+    } else {
+      seires_posts.push({ is_owner: 0 });
+    }
+
+    return seires_posts;
+  }
+
+  async updatePostSeriesSort(series_id: number, sort) {
+    for (let i = 0; i < sort.length; i++) {
+      await this.postSeriesRepository.updatePostSeriesSort(
+        series_id,
+        sort[i].post_id,
+        sort[i].sort,
+      );
+    }
+  }
+
+  // 게시글 리팩토링 할 때 해당 메서드 삭제할 예정
+  async deletePostSeries(post_id: number, seires_id: number) {
+    await this.postSeriesRepository.deletePostSeries(post_id, seires_id);
+  }
+
+  async deleteSeries(seires_id: number) {
+    await this.postSeriesRepository.deletePostSeries(null, seires_id);
+    await this.seriesRepository.deleteSeries(seires_id);
+  }
 
   async createPostSeries(post_id: number, series_id: number, user_id: number) {
     const get_sort = await this.postSeriesRepository.selectPostSeriesSort(
@@ -21,26 +78,6 @@ export class SeriesService {
     }
 
     await this.postSeriesRepository.createPostSeries(post_id, series_id, sort);
-
-    await this.seriesRepository.updateSeriesPostCount(user_id);
-  }
-
-  async deletePostSeries(post_id: number, user_id: number, seires_id: number) {
-    await this.postSeriesRepository.deletePostSeries(post_id, 0);
-
-    await this.seriesRepository.updateSeriesPostCount(user_id);
-  }
-
-  async createSeries(user_id: number, series_name: string) {
-    await this.seriesRepository.createSeries(user_id, series_name);
-
-    return this.selectSeriesList(user_id);
-  }
-
-  async selectSeriesList(user_id: number) {
-    const series = await this.seriesRepository.selectSeriesList(user_id);
-
-    return series;
   }
 
   async selectPostSeriesList(post_id: number) {
@@ -49,37 +86,5 @@ export class SeriesService {
     );
 
     return post_series;
-  }
-
-  async selectSeriesDetail(
-    user_id: number,
-    series_id: number,
-    sort: string,
-    pagination: PaginationDto,
-  ) {
-    const series = await this.seriesRepository.selectSeriesDetail(
-      user_id,
-      series_id,
-      sort,
-      pagination.offset,
-      pagination.limit,
-    );
-
-    return series;
-  }
-
-  async updatePostSeriesSort(series_id: number, sort) {
-    for (let i = 0; i < sort.length; i++) {
-      await this.postSeriesRepository.updatePostSeriesSort(
-        series_id,
-        Number.parseInt(sort[i].post_id),
-        sort[i].sort,
-      );
-    }
-  }
-
-  async deleteSeries(seires_id: number) {
-    await this.postSeriesRepository.deletePostSeries(0, seires_id);
-    await this.seriesRepository.deleteSeries(seires_id);
   }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 시리즈 생성/조회/수정/삭제 리팩토링

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

1. postController와 lologController에 작성되었던 시리즈 생성/조회/수정/삭제 기능을 seriesController로 이동.
2. post_series 테이블에 게시글이 삽입/삭제 될 때 트리거를 활용하여 series 테이블의 post_count가 update 되도록 수정
 -> 기존의 update 메서드는 삭제
3. enum을 사용하여 queryDto 생성. query로 받아오는 값이 고정되어 있을 경우, 다른 값이 넘어오면 오류가 발생하도록 처리.

<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
