### PR TITLE
refactor: 댓글 생성/읽기/수정/삭제

### DIFF
--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -8,22 +8,23 @@ import {
   Delete,
   BadRequestException,
 } from '@nestjs/common';
-import { CommentDto } from 'src/dto/comment/comment.dto';
+import { CommentsDto } from 'src/dto/comment/comments.dto';
 import { CommentService } from './comment.service';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { GetUser } from 'src/custom-decorator/get-user.decorator';
 import { User } from 'src/entity/user.entity';
+import { CommentsParamDto } from 'src/dto/comment/comments.param.dto';
 
 @Controller('comments')
 @UseGuards(JwtAuthGuard)
 export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
-  @Post('/:post_id')
+  @Post('/:id')
   async createCommnet(
-    @Body() data: CommentDto,
+    @Body() data: CommentsDto,
     @GetUser() user: User,
-    @Param('post_id') post_id: number,
+    @Param('id') post_id: number,
   ) {
     const result = await this.commentService.createComment(
       data,
@@ -35,25 +36,20 @@ export class CommentController {
 
     return {
       statusCode: 201,
-      post: result.post.post,
-      next_post: result.post.next_post,
-      pre_post: result.post.pre_post,
-      comments: result.comments,
+      comments: result,
     };
   }
 
-  @Patch('/:post_id/:comment_id')
+  @Patch('/:comment_id')
   async updateComment(
-    @Body() data: CommentDto,
-    @Param('comment_id') comment_id: number,
-    @Param('post_id') post_id: number,
     @GetUser() user: User,
+    @Param() params: CommentsParamDto,
+    @Body() data: CommentsDto,
   ) {
     const result = await this.commentService.updateComment(
-      data,
-      comment_id,
-      post_id,
       user.id,
+      params,
+      data,
     );
 
     if (result == 0) throw new BadRequestException('comment update failed');
@@ -61,28 +57,23 @@ export class CommentController {
     return {
       statusCode: 200,
       message: 'comment update success',
-      result: result,
+      comments: result,
     };
   }
 
   @Delete('/:post_id/:comment_id')
   async deleteComment(
-    @Param('comment_id') comment_id: number,
-    @Param('post_id') post_id: number,
     @GetUser() user: User,
+    @Param() params: CommentsParamDto,
   ) {
-    const result = await this.commentService.deleteComment(
-      comment_id,
-      post_id,
-      user.id,
-    );
+    const result = await this.commentService.deleteComment(user.id, params);
 
     if (result == 0) throw new BadRequestException('comment delete failed');
 
     return {
       statusCode: 200,
       message: 'comment delete success',
-      result: result,
+      comments: result,
     };
   }
 }

--- a/src/comment/comment.module.ts
+++ b/src/comment/comment.module.ts
@@ -1,16 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { PostModule } from 'src/post/post.module';
 import { CommentRepository } from 'src/repository/comment.repository';
-import { PostRepository } from 'src/repository/post.repository';
 import { CommentController } from './comment.controller';
 import { CommentService } from './comment.service';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([CommentRepository, PostRepository]),
-    PostModule,
-  ],
+  imports: [TypeOrmModule.forFeature([CommentRepository])],
   exports: [TypeOrmModule, CommentService],
   controllers: [CommentController],
   providers: [CommentService],

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -1,16 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { CommentDto } from 'src/dto/comment/comment.dto';
-import { PostService } from 'src/post/post.service';
+import { CommentsDto } from 'src/dto/comment/comments.dto';
+import { CommentsParamDto } from 'src/dto/comment/comments.param.dto';
 import { CommentRepository } from 'src/repository/comment.repository';
-import { PostRepository } from 'src/repository/post.repository';
 
 @Injectable()
 export class CommentService {
-  constructor(
-    private commentRepository: CommentRepository,
-    private postRepository: PostRepository,
-    private postService: PostService,
-  ) {}
+  constructor(private commentRepository: CommentRepository) {}
 
   async selectCommentList(post_id: number, user_id: number) {
     let result = await this.commentRepository.selectCommentList(
@@ -26,12 +21,12 @@ export class CommentService {
       }
     }
 
+    if (result.length == 0) return null;
+
     return result;
   }
 
-  async createComment(data: CommentDto, post_id: number, user_id: number) {
-    if (data.depth == 1 && !data.parent_id) return 0;
-
+  async createComment(data: CommentsDto, post_id: number, user_id: number) {
     const result = await this.commentRepository.createComment(
       data,
       post_id,
@@ -40,47 +35,38 @@ export class CommentService {
 
     if (result == 0) return 0;
 
-    await this.postRepository.updateCommentCount(post_id);
-
     const comments = await this.selectCommentList(post_id, user_id);
-    const post = await this.postService.selectPostOne(user_id, post_id);
-
-    return { post, comments };
+    return comments;
   }
 
   async updateComment(
-    data: CommentDto,
-    comment_id: number,
-    post_id: number,
     user_id: number,
+    params: CommentsParamDto,
+    data: CommentsDto,
   ) {
     const result = await this.commentRepository.updateComment(
       data,
-      comment_id,
+      params.comment_id,
       user_id,
     );
 
     if (result == 0) return 0;
 
-    const comments = await this.selectCommentList(post_id, user_id);
-    const post = await this.postService.selectPostOne(user_id, post_id);
+    const comments = await this.selectCommentList(params.post_id, user_id);
 
-    return { post, comments };
+    return comments;
   }
 
-  async deleteComment(comment_id: number, post_id: number, user_id: number) {
+  async deleteComment(user_id: number, params: CommentsParamDto) {
     const result = await this.commentRepository.deleteComment(
-      comment_id,
+      params.comment_id,
       user_id,
     );
 
     if (result == 0) return 0;
 
-    await this.postRepository.updateCommentCount(post_id);
+    const comments = await this.selectCommentList(params.post_id, user_id);
 
-    const comments = await this.selectCommentList(post_id, user_id);
-    const post = await this.postService.selectPostOne(user_id, post_id);
-
-    return { post, comments };
+    return comments;
   }
 }

--- a/src/dto/comment/comments.dto.ts
+++ b/src/dto/comment/comments.dto.ts
@@ -9,17 +9,10 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
-export class CommentDto {
+export class CommentsDto {
   @IsString()
   @IsNotEmpty()
   content: string;
-
-  @IsOptional()
-  @IsNumber()
-  @IsNotEmpty()
-  @Min(0)
-  @Max(1)
-  depth: number;
 
   @IsOptional()
   @IsNumber()

--- a/src/dto/comment/comments.param.dto.ts
+++ b/src/dto/comment/comments.param.dto.ts
@@ -1,0 +1,14 @@
+import { IsNumber, IsNotEmpty } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CommentsParamDto {
+  @IsNotEmpty()
+  @IsNumber()
+  @Type(() => Number)
+  post_id: number;
+
+  @IsNotEmpty()
+  @IsNumber()
+  @Type(() => Number)
+  comment_id: number;
+}

--- a/src/entity/comment.entity.ts
+++ b/src/entity/comment.entity.ts
@@ -7,20 +7,20 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
+  JoinTable,
 } from 'typeorm';
+import { NestedCommentsView } from './comments-view.entity';
 import { Post } from './post.entity';
 import { User } from './user.entity';
 
 @Entity({ name: 'comments' })
-export class Comment extends BaseEntity {
+export class Comments extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column()
   content: string;
-
-  @Column({ type: 'tinyint', default: 0 })
-  depth: number;
 
   @CreateDateColumn()
   create_at: Date;
@@ -28,8 +28,8 @@ export class Comment extends BaseEntity {
   @UpdateDateColumn()
   update_at: Date;
 
-  @ManyToOne((type) => Comment)
-  @JoinColumn({ name: 'paren_id' })
+  @ManyToOne((type) => Comments)
+  @JoinColumn({ name: 'parent_id' })
   comment: number;
 
   @ManyToOne((type) => User, { onDelete: 'CASCADE' })
@@ -39,4 +39,20 @@ export class Comment extends BaseEntity {
   @ManyToOne((type) => Post, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'post_id' })
   post: number;
+
+  @OneToMany(
+    (type) => NestedCommentsView,
+    (nested_comments) => nested_comments.comment,
+  )
+  @JoinTable({
+    joinColumn: {
+      name: 'nested_comments',
+      referencedColumnName: 'parent_id',
+    },
+    inverseJoinColumn: {
+      name: 'comments',
+      referencedColumnName: 'id',
+    },
+  })
+  nested_comments: NestedCommentsView;
 }

--- a/src/entity/comments-view.entity.ts
+++ b/src/entity/comments-view.entity.ts
@@ -1,0 +1,33 @@
+import { JoinColumn, ManyToOne, ViewColumn, ViewEntity } from 'typeorm';
+import { Comments } from './comment.entity';
+
+@ViewEntity({
+  expression: `SELECT
+  child.parent_id,
+  JSON_ARRAYAGG(
+      JSON_OBJECT(
+          'user_id', user.id,
+        'comment_login_id', user.login_id,
+        'comment_profile_image', user.profile_image,
+        'comment_id', child.id,
+        'content', child.content,
+        'depth', child.depth,
+        'create_at', child.create_at,
+        'is_comments_writer', IF(user.id = 1, 'true', 'false')
+      )
+  ) AS nested_comments
+  FROM comments child
+  INNER JOIN comments parent ON parent.id = child.parent_id
+  LEFT JOIN user ON user.id = child.user_id
+  GROUP BY parent.id
+  ORDER BY child.create_at DESC;
+  `,
+})
+export class NestedCommentsView {
+  @ManyToOne((type) => Comments)
+  @JoinColumn({ name: 'parent_id' })
+  comment: number;
+
+  @ViewColumn()
+  nested_comments: string[];
+}

--- a/src/lolog/lolog.controller.ts
+++ b/src/lolog/lolog.controller.ts
@@ -64,12 +64,12 @@ export class LologController {
 
     return {
       statusCode: 200,
-      series: result.series[0],
+      series: result.series,
       post: result.post.post[0],
       next_post: result.post.next_post[0],
       pre_post: result.post.pre_post[0],
-      comments: result.comments[0],
-      interested: result.post.interested_posts[0],
+      comments: result.comments,
+      interested: result.post.interested_posts,
     };
   }
 

--- a/src/repository/comment.repository.ts
+++ b/src/repository/comment.repository.ts
@@ -1,15 +1,38 @@
-import { CommentDto } from 'src/dto/comment/comment.dto';
-import { Comment } from 'src/entity/comment.entity';
+import { CommentsDto } from 'src/dto/comment/comments.dto';
+import { Comments } from 'src/entity/comment.entity';
 import { EntityRepository, Repository } from 'typeorm';
 
-@EntityRepository(Comment)
-export class CommentRepository extends Repository<Comment> {
-  async createComment(data: CommentDto, post_id: number, user_id: number) {
+@EntityRepository(Comments)
+export class CommentRepository extends Repository<Comments> {
+  async selectCommentList(post_id: number, user_id: number) {
+    const comments = this.createQueryBuilder('comments')
+      .leftJoin('post', 'post', 'post.id = comments.post_id')
+      .leftJoin('comments.user', 'user')
+      .leftJoin('comments.nested_comments', 'nested_comments')
+      .select([
+        'post.id AS post_id',
+        'user.id AS user_id',
+        'user.login_id AS comment_login_id',
+        'user.profile_image AS comment_profile_image',
+        'comments.id AS comment_id',
+        'comments.content',
+        'comments.depth',
+        'comments.create_at',
+        'nested_comments.nested_comments as nested_comments',
+        'IF(user.id = :user_id, 1, 0) AS is_comments_write',
+      ])
+      .setParameter('user_id', user_id)
+      .where('post.id = :post_id', { post_id: post_id })
+      .orderBy('comments.create_at', 'DESC');
+
+    return await comments.getRawMany();
+  }
+
+  async createComment(data: CommentsDto, post_id: number, user_id: number) {
     const comment = this.create({
       user: user_id,
       post: post_id,
       content: data.content,
-      depth: data.depth,
       comment: data.parent_id,
     });
 
@@ -21,9 +44,9 @@ export class CommentRepository extends Repository<Comment> {
     }
   }
 
-  async updateComment(data: CommentDto, comment_id: number, user_id: number) {
+  async updateComment(data: CommentsDto, comment_id: number, user_id: number) {
     const comment = this.createQueryBuilder()
-      .update(Comment)
+      .update(Comments)
       .set({
         content: data.content,
       })
@@ -43,7 +66,7 @@ export class CommentRepository extends Repository<Comment> {
   async deleteComment(comment_id: number, user_id: number) {
     const comment = this.createQueryBuilder()
       .delete()
-      .from(Comment)
+      .from(Comments)
       .where(`id = :comment_id AND user_id = :user_id`, {
         comment_id: comment_id,
         user_id: user_id,
@@ -55,54 +78,5 @@ export class CommentRepository extends Repository<Comment> {
     } catch (err) {
       return 0;
     }
-  }
-
-  async selectCommentList(post_id: number, user_id: number) {
-    const comment = await this.query(
-      `WITH nested_comments AS (
-        SELECT 
-        comments.id AS comment_id,
-        JSON_ARRAYAGG(
-           JSON_OBJECT(
-           'nested_comment_user_id', user.id,
-           'nested_comment_login_id', user.login_id,
-           'nested_comment_profile_image', user.profile_image,
-          'nested_comment_id', nc.id,
-           'nested_comment_content', nc.content,
-           'nested_comment_depth', nc.depth,
-           'nested_comment_create_at', nc.create_at,
-           'nested_comment_update_at', nc.update_at,
-           'nested_comments_is_writer', IF(user.id = ?, 'true', 'false')
-           )
-        ) as nested_comments
-        FROM comments
-        INNER JOIN comments nc ON nc.paren_id = comments.id AND nc.depth = 1
-        LEFT JOIN user ON user.id = nc.user_id
-      )
-      
-      SELECT 
-      post.id AS post_id,
-      user.id AS user_id,
-      user.login_id AS comment_login_id,
-      user.profile_image AS comment_profile_image,
-      comments.id AS comment_id,
-      comments.content,
-      comments.depth,
-      comments.create_at,
-      comments.update_at,
-      nc.nested_comments,
-      IF(user.id = ?, 1, 0) AS comments_is_writer
-      FROM comments
-      LEFT JOIN post ON post.id = comments.post_id
-      LEFT JOIN user ON user.id = comments.user_id
-      LEFT JOIN nested_comments nc ON nc.comment_id = comments.id
-      WHERE post.id = ?
-      ORDER BY comments.id DESC`,
-      [user_id, user_id, post_id],
-    );
-
-    if (comment.length <= 0) return 0;
-
-    return comment;
   }
 }

--- a/src/repository/post.repository.ts
+++ b/src/repository/post.repository.ts
@@ -185,13 +185,6 @@ export class PostRepository extends Repository<Post> {
     return pre_post;
   }
 
-  async updateCommentCount(post_id: number) {
-    await this.query(
-      `UPDATE post SET comment_count = (SELECT COUNT(*) FROM comments WHERE post_id = ?) WHERE id = ?`,
-      [post_id, post_id],
-    );
-  }
-
   async updateLikeCount(post_id: number) {
     await this.query(
       `UPDATE post SET likes = (SELECT COUNT(*) FROM post_like WHERE post_id = ?) WHERE id = ?`,


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 댓글 생성/읽기/수정/삭제 리팩토링

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

1. 댓글 생성/수정/삭제 시에 댓글 목록만 불러오도록 수정
2. 댓글 읽기 쿼리 수정 -> view 테이블 추가하여 WHIT 절 제외. TypeORM 문법으로 수정
3. 댓글 생성/삭제 시에 post 테이블의 comment_count를 트리거로 설정

<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
