### PR TITLE
fix : update_alert 수정 안되는 버그 수정

### DIFF
--- a/src/dto/user/update-user.dto.ts
+++ b/src/dto/user/update-user.dto.ts
@@ -38,10 +38,10 @@ export class UpdateUserDto {
   social_info_url?: string;
 
   @IsBooleanOrNull({ message: 'comment_alert must be a 1 or 0 or Null' })
-  comment_alert?: number;
+  comment_alert?: boolean;
 
   @IsBooleanOrNull({ message: 'update_alert must be a 1 or 0 or Null' })
-  update_alert?: number;
+  update_alert?: boolean;
 }
 
 export class SocialInfoDto extends PickType(UpdateUserDto, [

--- a/src/entity/comment.entity.ts
+++ b/src/entity/comment.entity.ts
@@ -22,6 +22,9 @@ export class Comments extends BaseEntity {
   @Column()
   content: string;
 
+  @Column()
+  depth: number;
+
   @CreateDateColumn()
   create_at: Date;
 

--- a/src/entity/user.entity.ts
+++ b/src/entity/user.entity.ts
@@ -37,8 +37,8 @@ export class User extends BaseEntity {
   @Column({ nullable: true })
   title: string;
 
-  @Column({ default: 0 })
-  comment_alert: number;
+  @Column({ default: false })
+  comment_alert: boolean;
 
   @Column({ default: false })
   update_alert: boolean;

--- a/src/repository/user.repository.ts
+++ b/src/repository/user.repository.ts
@@ -74,7 +74,7 @@ export class UserRepository extends Repository<User> {
   async getMe(id: number) {
     return await this.query(
       `
-      SELECT count(follow.id) as followCount, u.id, u.profile_image, u.name, u.about_me, u.title, u.email, u.comment_alert, u.update_alert, si.email social_info_email, si.github social_info_github, si. twitter social_info_twitter, si.facebook social_info_facebook, si.url social_info_url
+      SELECT count(follow.id) as follow_count, u.id, u.profile_image, u.name, u.about_me, u.title, u.email, u.comment_alert, u.update_alert, si.email social_info_email, si.github social_info_github, si. twitter social_info_twitter, si.facebook social_info_facebook, si.url social_info_url
         FROM user u
         LEFT JOIN social_info si ON si.userId = u.id
         LEFT JOIN follow ON u.id = follow.followee_id

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -79,6 +79,9 @@ export class UserController {
           break;
 
         case 'alert':
+          if (!(updateUserDto.comment_alert && updateUserDto.update_alert)) {
+            throw new Error('comment_alert && update_alert must be entered');
+          }
           updateData = {
             comment_alert: updateUserDto.comment_alert,
             update_alert: updateUserDto.update_alert,
@@ -96,7 +99,8 @@ export class UserController {
         );
       } else if (
         err.message === 'title must be entered' ||
-        err.message === 'name must be entered'
+        err.message === 'name must be entered' ||
+        err.message === 'comment_alert && update_alert must be entered'
       ) {
         console.log(err);
         throw new BadRequestException(err.message);
@@ -111,7 +115,7 @@ export class UserController {
   @UsePipes(ValidationPipe)
   @UseGuards(JwtAuthGuard)
   @HttpCode(201)
-  async udpateProfileImage(
+  async updateProfileImage(
     @Body('profile_image') profile_image: string,
     @GetUser() user: User,
   ) {


### PR DESCRIPTION
update_alert을 수정해도 db상에 변경되지 않던 버그 수정
comment_alert, update_alert가 입력되지않을 떄 예외처리 추가
프로필이미지 업데이트 관련 함수명 오타 수정(udpateProfileImage ->
updateProfileImage)
getMe에 followCount를 follow_count로 변경

## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- update_alert 수정 안되는 버그 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

- update_alert 수정이 안되는 버그 수정
- comment_alert, update_alert 관련 예외처리 추가
- 프로필이미지 관련 함수명 오타 수정
- getMe에 나를 팔로우하는 사람의 수를 나타내는 followCount를 follow_count로 변경

<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
