### PR TITLE
fix : 유저 알람 설정 버그 수정

### DIFF
--- a/src/dto/user/update-user.dto.ts
+++ b/src/dto/user/update-user.dto.ts
@@ -38,10 +38,10 @@ export class UpdateUserDto {
   social_info_url?: string;
 
   @IsBooleanOrNull({ message: 'comment_alert must be a 1 or 0 or Null' })
-  comment_alert?: boolean;
+  comment_alert?: number;
 
   @IsBooleanOrNull({ message: 'update_alert must be a 1 or 0 or Null' })
-  update_alert?: boolean;
+  update_alert?: number;
 }
 
 export class SocialInfoDto extends PickType(UpdateUserDto, [

--- a/src/entity/user.entity.ts
+++ b/src/entity/user.entity.ts
@@ -37,11 +37,11 @@ export class User extends BaseEntity {
   @Column({ nullable: true })
   title: string;
 
-  @Column({ default: false })
-  comment_alert: boolean;
+  @Column({ default: 0 })
+  comment_alert: number;
 
-  @Column({ default: false })
-  update_alert: boolean;
+  @Column({ default: 0 })
+  update_alert: number;
 
   @Column({ nullable: true })
   provider: string;

--- a/src/lolog/lolog.controller.ts
+++ b/src/lolog/lolog.controller.ts
@@ -63,7 +63,7 @@ export class LologController {
   @UseGuards(JwtAuthGuard)
   async likePost(@Param('post_id') post_id: number, @GetUser() user: User) {
     await this.lologService.likePost(user.id, post_id);
-    return { statusCode: 200 };
+    return { statusCode: 201 };
   }
 
   @Delete('/:post_id/like')

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -23,7 +23,11 @@ export class SearchController {
     @Query('limit') limit: number,
     @ValidateToken() user: User,
   ) {
-    const pagination: PaginationDto = { offset: offset, limit: limit };
+    const pagination: PaginationDto = {
+      offset: offset,
+      limit: limit,
+      tag_id: null,
+    };
     const data = await this.searchService.mainSearch(
       keyword,
       user_id,

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -34,7 +34,7 @@ export class UserController {
     @Query('type') type: string,
     @GetUser() user: User,
   ) {
-    // type: [title, name, profile_image, social_info]
+    // type: [title, name, social_info]
     const id = user.id;
     try {
       let data: any = '';
@@ -73,13 +73,13 @@ export class UserController {
           data = await this.userService.updateUser(id, updateData);
           break;
 
-        case 'profile_image':
-          updateData = { profile_image: updateUserDto.profile_image };
-          data = await this.userService.updateUser(id, updateData);
-          break;
-
         case 'alert':
-          if (!(updateUserDto.comment_alert && updateUserDto.update_alert)) {
+          if (
+            !(
+              updateUserDto.comment_alert in [0, 1] &&
+              updateUserDto.update_alert in [0, 1]
+            )
+          ) {
             throw new Error('comment_alert && update_alert must be entered');
           }
           updateData = {


### PR DESCRIPTION
알람 설정 값을 true, false로 받아오고 예외처리를 모두 true일 경우에만
허용하게 해서 대부분의 값이 예외처리되는 현상 수정

## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 알람 설정 업데이트 관련 예외처리 버그 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

알람을 ture / false로 받아오고 예외처리로 모두 true 일 때만 허용되도록 설정이 되어서 대부분 예외처리가 되는 현상 발생
- 알람을 1 / 0으로 받아오고 예외처리 조건에 in [0, 1]을 사용하여 예외처리 진행

<br />

## :: 기타 질문 및 특이 사항

