### PR TITLE
fix: 시리즈에 포함된 게시글 목록 읽기 수정

### DIFF
--- a/src/series/series.controller.ts
+++ b/src/series/series.controller.ts
@@ -56,7 +56,6 @@ export class SeriesController {
   }
 
   @Patch('/:id')
-  @UseGuards(JwtAuthGuard)
   async updatePostSeriesSort(
     @Param('id') series_id: number,
     @Body('sort') sort,
@@ -67,7 +66,6 @@ export class SeriesController {
   }
 
   @Delete('/:id')
-  @UseGuards(JwtAuthGuard)
   async deleteSeries(@Param('id') series_id: number) {
     await this.seriesService.deleteSeries(series_id);
 

--- a/src/series/series.controller.ts
+++ b/src/series/series.controller.ts
@@ -3,7 +3,6 @@ import {
   UseGuards,
   Post,
   Body,
-  BadRequestException,
   Get,
   Param,
   Query,
@@ -16,25 +15,25 @@ import { GetUser } from 'src/custom-decorator/get-user.decorator';
 import { User } from 'src/entity/user.entity';
 import { CreateSeriesDto } from 'src/dto/series/create-series.dto';
 import { SelectSereisPostsDto } from 'src/dto/series/select-series-posts.dto';
+import { ValidateToken } from 'src/custom-decorator/validate-token.decorator';
 
 @Controller('series')
-@UseGuards(JwtAuthGuard)
 export class SeriesController {
   constructor(private readonly seriesService: SeriesService) {}
 
   @Post('')
+  @UseGuards(JwtAuthGuard)
   async createSeries(@GetUser() user: User, @Body() data: CreateSeriesDto) {
     const result = await this.seriesService.createSeries(
       user.id,
       data.series_name,
     );
 
-    if (result == 0) throw new BadRequestException(`create series failed`);
-
     return { statusCode: 200, series: result };
   }
 
   @Get('')
+  @UseGuards(JwtAuthGuard)
   async selectSeriesList(@GetUser() user: User) {
     const result = await this.seriesService.selectSeriesList(user.id);
 
@@ -43,20 +42,21 @@ export class SeriesController {
 
   @Get('/:id')
   async SelectSereisPosts(
-    @GetUser() user: User,
     @Param('id') series_id: number,
     @Query() sort: SelectSereisPostsDto,
+    @ValidateToken() user?: User,
   ) {
     const result = await this.seriesService.SelectSereisPosts(
-      user.id,
       series_id,
       sort,
+      user,
     );
 
     return { statusCode: 200, series: result };
   }
 
   @Patch('/:id')
+  @UseGuards(JwtAuthGuard)
   async updatePostSeriesSort(
     @Param('id') series_id: number,
     @Body('sort') sort,
@@ -67,6 +67,7 @@ export class SeriesController {
   }
 
   @Delete('/:id')
+  @UseGuards(JwtAuthGuard)
   async deleteSeries(@Param('id') series_id: number) {
     await this.seriesService.deleteSeries(series_id);
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 시리즈에 포함된 게시글 목록 읽기 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

1. 시리즈에 포함된 게시글 목록 읽기 수정
- 시리즈 소유자 여부를 select해서 보내도록 수정
- 해당 시리즈에 포스트가 없을 경우 null을 보내도록 수정
- 로그인하지 않은 사용자도 볼 수 있도록 수정

2. 그 외
- 예외처리 부분 수정 및 불필요한 코드 삭제
<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
