### PR TITLE
feature : 프로필이미지 파일 업로드 기능 추가

### DIFF
--- a/src/exception/globalExceptionFilter.ts
+++ b/src/exception/globalExceptionFilter.ts
@@ -6,6 +6,7 @@ import {
   Injectable,
   BadRequestException,
   UnauthorizedException,
+  NotFoundException,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { QueryFailedError } from 'typeorm';
@@ -28,9 +29,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
         break;
       case BadRequestException:
         status = (exception as any).response.statusCode;
-        message = (exception as any).response.message[0];
+        message = (exception as any).response.message;
         break;
       case UnauthorizedException:
+        status = (exception as any).response.statusCode;
+        message = (exception as any).response.message;
+        break;
+      case NotFoundException:
         status = (exception as any).response.statusCode;
         message = (exception as any).response.message;
         break;

--- a/src/repository/user.repository.ts
+++ b/src/repository/user.repository.ts
@@ -71,6 +71,14 @@ export class UserRepository extends Repository<User> {
       .execute();
   }
 
+  async deleteProfileImage(id: number) {
+    await this.createQueryBuilder()
+      .update()
+      .set({ profile_image: null })
+      .where('id = :id', { id })
+      .execute();
+  }
+
   async getMe(id: number) {
     return await this.query(
       `

--- a/src/upload/upload.controller.ts
+++ b/src/upload/upload.controller.ts
@@ -30,7 +30,7 @@ export class UploadController {
 
   @Delete('/thumbnail')
   thumbnailDelete(@Query('image_url') image_url: string) {
-    this.thumbnailDelete(image_url);
+    this.uploadService.thumbnailDelete(image_url);
 
     return {
       statusCode: 200,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -5,6 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { SocialInfoDto } from 'src/dto/user/update-user.dto';
+import { deleteImageFile, getImageURL } from 'src/lib/multerOptions';
 import { FollowRepository } from 'src/repository/follow.repository';
 import { SocialInfoRepository } from 'src/repository/social-info.repository';
 import { UserRepository } from 'src/repository/user.repository';
@@ -44,10 +45,22 @@ export class UserService {
     return await this.socialInfoRepository.getSocialInfoByUserId(id, keys);
   }
 
-  async updateProfileImage(id: number, profile_image: string) {
-    await this.userRepository.updateProfileImage(id, profile_image);
+  async updateProfileImage(id: number, image_url: string, files: File[]) {
+    if (image_url) {
+      const file_name = image_url.replace('http://localhost:8000/public/', '');
+      deleteImageFile(file_name);
+    }
+    const url = getImageURL(files)[0];
+    await this.userRepository.updateProfileImage(id, url);
 
     return this.userRepository.getUserByUserId(id, ['profile_image']);
+  }
+
+  async deleteProfileImage(id: number, image_url: string) {
+    const file_name = image_url.replace('http://localhost:8000/public/', '');
+    deleteImageFile(file_name);
+
+    await this.userRepository.deleteProfileImage(id);
   }
 
   async follow(followerId: number, followeeId: number) {


### PR DESCRIPTION
기존의 링크만 저장하는 방식에서 파일까지 저장하는 방식으로 변경

## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 프로필 이미지를 파일까지 저장

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

프로필 이미지 저장
- FilesInterceptor과 multerOptions를 사용하여 파일을 저장 및 해당 파일의 주소를 user 테이블의 profile_image에 저장
- 이미지 변경 시 기존 파일의 url을 query params로 받아와 해당 파일을 제거 후 새로운 파일을 저장 및 user 테이블에 반영

프로필 이미지 제거
- 기존 파일의 url을 query params로 받아와 해당 파일 제거 후 user테이블의 profile_image를 null으로 변경
<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
