### PR TITLE
refactor : 메일 전송을 gmail으로 변경

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -19,12 +19,12 @@ import { FacebookStrategy } from './strategies/facebook.strategy';
     TypeOrmModule.forFeature([UserRepository]),
     MailerModule.forRoot({
       transport: {
-        service: 'Naver',
-        host: 'smtp.naver.com',
+        service: 'Gmail',
+        host: 'smtp.gmail.com',
         port: 587,
         auth: {
-          user: 'velog-clone-project', // generated ethereal user
-          pass: 'velog-clone1!', // generated ethereal password
+          user: process.env.GMAIL_LOGIN_ID, // generated ethereal user
+          pass: process.env.GMAIL_PASSWORD, // generated ethereal password
         },
       },
     }),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -16,11 +16,13 @@ export class AuthService {
   ) {}
 
   async sendEmail(email: string) {
-    const code: string = Math.round(Math.random() * 10000).toString();
+    const code: string = Math.round(Math.random() * 10000)
+      .toString()
+      .padStart(4, '0');
     this.mailerService
       .sendMail({
         to: email, // List of receivers email address
-        from: 'velog-clone-project@naver.com', // Senders email address
+        from: 'lologproject@gmail.com', // Senders email address
         subject: 'Velog-clone-project signup code ✔', // Subject line
         text: `signup code is : ${code}`, // plaintext body
         html: `signup code is : <b>${code}</b>`, // HTML body content


### PR DESCRIPTION
naver으로 전송을 하다보니 너무 많이 보내서 스팸 계정으로 더이상 메일을
못보내는 현상 발생

gmail으로 변경

## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- naver 메일 전송에서 gmail으로 변경

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

naver메일을 너무 많이 보내서 스팸처리로 더이상 메일 전송이 안되는 바람에 gmail으로 변경했습니다.
gmail 아이디와 비밀번호는 env 파일에 저장했습니다.

<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
