### PR TITLE
fix: 버그수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "^9.0.0",
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^8.0.0",
+        "@nestjs/serve-static": "^2.2.2",
         "@nestjs/typeorm": "^8.0.2",
         "@types/bcryptjs": "^2.4.2",
         "@types/cors": "^2.8.12",
@@ -1932,6 +1933,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-2.2.2.tgz",
+      "integrity": "sha512-3Mr+Q/npS3N7iGoF3Wd6Lj9QcjMGxbNrSqupi5cviM0IKrZ1BHl5qekW95rWYNATAVqoTmjGROAq+nKKpuUagQ==",
+      "dependencies": {
+        "path-to-regexp": "0.1.7"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@nestjs/core": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@nestjs/serve-static/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "node_modules/@nestjs/testing": {
       "version": "8.4.7",
@@ -4248,9 +4266,9 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "node_modules/dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -5480,23 +5498,26 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "dependencies": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/formidable/node_modules/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
       },
@@ -14135,6 +14156,21 @@
         }
       }
     },
+    "@nestjs/serve-static": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-2.2.2.tgz",
+      "integrity": "sha512-3Mr+Q/npS3N7iGoF3Wd6Lj9QcjMGxbNrSqupi5cviM0IKrZ1BHl5qekW95rWYNATAVqoTmjGROAq+nKKpuUagQ==",
+      "requires": {
+        "path-to-regexp": "0.1.7"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+        }
+      }
+    },
     "@nestjs/testing": {
       "version": "8.4.7",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-8.4.7.tgz",
@@ -15970,9 +16006,9 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "requires": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -16908,20 +16944,23 @@
       }
     },
     "formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
       "requires": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
       },
       "dependencies": {
         "qs": {
-          "version": "6.9.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/jwt": "^9.0.0",
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-express": "^8.0.0",
+    "@nestjs/serve-static": "^2.2.2",
     "@nestjs/typeorm": "^8.0.2",
     "@types/bcryptjs": "^2.4.2",
     "@types/cors": "^2.8.12",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,10 +13,15 @@ import { SearchModule } from './search/search.module';
 import { UploadModule } from './upload/upload.module';
 import { GlobalExceptionFilter } from './exception/globalExceptionFilter';
 import { APP_FILTER } from '@nestjs/core';
+import { ServeStaticModule } from '@nestjs/serve-static';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot(),
+    ServeStaticModule.forRoot({
+      rootPath: 'public',
+      serveRoot: '/public',
+    }),
     UserModule,
     AuthModule,
     PostModule,
@@ -29,7 +34,6 @@ import { APP_FILTER } from '@nestjs/core';
     SearchModule,
     UploadModule,
   ],
-  // providers: [],
   providers: [
     {
       provide: APP_FILTER,

--- a/src/lib/multerOptions.ts
+++ b/src/lib/multerOptions.ts
@@ -50,7 +50,7 @@ export const getImageURL = (files: File[]) => {
   return generatedFiles;
 };
 
-export const deleteImageFile = (file_name) => {
+export const deleteImageFile = file_name => {
   if (existsSync('./public/' + file_name)) {
     unlinkSync('./public/' + file_name);
   }

--- a/src/lolog/lolog.module.ts
+++ b/src/lolog/lolog.module.ts
@@ -1,11 +1,9 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { CommentModule } from 'src/comment/comment.module';
 import { PostModule } from 'src/post/post.module';
 import { PostLikeRepository } from 'src/repository/post-like.repository';
 import { SeriesModule } from 'src/series/series.module';
-import { TagModule } from 'src/tag/tag.module';
 import { UserModule } from 'src/user/user.module';
 import { LologController } from './lolog.controller';
 import { LologService } from './lolog.service';
@@ -13,7 +11,6 @@ import { LologService } from './lolog.service';
 @Module({
   imports: [
     PostModule,
-    TagModule,
     SeriesModule,
     UserModule,
     TypeOrmModule.forFeature([PostLikeRepository]),

--- a/src/lolog/lolog.service.ts
+++ b/src/lolog/lolog.service.ts
@@ -1,36 +1,25 @@
-import {
-  ConflictException,
-  ForbiddenException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { PostService } from 'src/post/post.service';
 import { SeriesService } from 'src/series/series.service';
-import { TagService } from 'src/tag/tag.service';
 import { UserService } from 'src/user/user.service';
 import { PostLikeRepository } from 'src/repository/post-like.repository';
-import { PostRepository } from 'src/repository/post.repository';
 import { PaginationDto } from 'src/dto/pagination.dto';
 import { User } from 'src/entity/user.entity';
+import { PostTagRepository } from 'src/repository/post-tag.repository';
 
 @Injectable()
 export class LologService {
   constructor(
     private postService: PostService,
-    private tagService: TagService,
     private seriesService: SeriesService,
     private userService: UserService,
     private postLikeRepository: PostLikeRepository,
-    private postRepository: PostRepository,
+    private postTagRepository: PostTagRepository,
   ) {}
 
   async getLolog(user_id: number, pagination: PaginationDto, user?: User) {
-    const posts = await this.postService.selectPostList(
-      user_id,
-      pagination,
-      user,
-    );
-    const tags = await this.tagService.selectTagListByUserId(user_id);
+    const posts = await this.postService.selectPostList(user_id, pagination, user);
+    const tags = await this.postTagRepository.selectTagListByUserId(user_id);
 
     return { posts, tags };
   }
@@ -52,10 +41,7 @@ export class LologService {
   }
 
   async likePost(user_id: number, post_id: number) {
-    const data = await this.postLikeRepository.getLikedPostOne(
-      user_id,
-      post_id,
-    );
+    const data = await this.postLikeRepository.getLikedPostOne(user_id, post_id);
     if (data) {
       throw new ConflictException('이미 좋아요 한 게시글 입니다');
     }
@@ -63,10 +49,7 @@ export class LologService {
   }
 
   async unlikePost(user_id: number, post_id: number) {
-    const data = await this.postLikeRepository.getLikedPostOne(
-      user_id,
-      post_id,
-    );
+    const data = await this.postLikeRepository.getLikedPostOne(user_id, post_id);
     if (!data) {
       throw new NotFoundException('좋아요를 하지 않은 게시글입니다');
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,8 +5,6 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ConfigService } from 'config/config.service';
 import * as fs from 'fs';
-import * as express from 'express';
-import { join } from 'path';
 import { GlobalExceptionFilter } from './exception/globalExceptionFilter';
 
 async function bootstrap() {
@@ -23,8 +21,6 @@ async function bootstrap() {
       transform: true,
     }),
   );
-
-  app.use('/public', express.static(join(__dirname, '../public')));
 
   app.enableCors();
 

--- a/src/main/main.model.ts
+++ b/src/main/main.model.ts
@@ -8,4 +8,5 @@ export enum PeriodType {
   WEEK = 'week',
   MONTH = 'month',
   YEAR = 'year',
+  NULL = '',
 }

--- a/src/main/main.service.ts
+++ b/src/main/main.service.ts
@@ -8,12 +8,6 @@ export class MainService {
   constructor(private postRepository: PostRepository) {}
 
   async getMainPosts(query: SelectMainPostsDto) {
-    if (query.type == MainPostsType.TREND && !query.period) {
-      throw new BadRequestException(
-        `트랜딩을 조회할 땐 period가 필수 값 입니다.`,
-      );
-    }
-
     const posts = await this.postRepository.selectPostListForMain(
       query.type,
       query.period,

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -146,11 +146,16 @@ export class PostService {
       }
     }
 
+    if (posts.length == 0) return null;
+
     return posts;
   }
 
   async selectSaves(user_id: number) {
-    return await this.postRepository.selectSaves(user_id);
+    const saves = await this.postRepository.selectSaves(user_id);
+
+    if (saves.length == 0) return null;
+    return saves;
   }
 
   async createTag(tags: string[], post_id: number) {

--- a/src/repository/post-tag.repository.ts
+++ b/src/repository/post-tag.repository.ts
@@ -20,16 +20,23 @@ export class PostTagRepository extends Repository<PostTag> {
 
   async selectTagListByUserId(user_id: number) {
     const tags = await this.query(
-      `SELECT
-    COUNT(post_tag.tag_id) AS post_count,
-    tag.id AS tag_id,
-    tag.name
-    FROM post_tag
-    LEFT JOIN tag ON tag.id = post_tag.tag_id
-    LEFT JOIN post ON post.id = post_tag.post_id
-    WHERE post.user_id = ?
-    GROUP BY post_tag.tag_id`,
-      [user_id],
+      `(SELECT
+        COUNT(id) AS post_count,
+        0 AS tag_id,
+        '전체보기' AS name
+        FROM post 
+        WHERE user_id = ?)
+        UNION
+        (SELECT
+        COUNT(post_tag.tag_id) AS post_count,
+        tag.id AS tag_id,
+        tag.name
+        FROM post_tag
+        LEFT JOIN tag ON tag.id = post_tag.tag_id
+        LEFT JOIN post ON post.id = post_tag.post_id
+        WHERE post.user_id = ?
+        GROUP BY post_tag.tag_id);`,
+      [user_id, user_id],
     );
 
     return tags;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 임시글 목록 불러오기
- 메인 페이지 게시글 목록 불러오기
- 롤로그 태그 목록 불러오기
- 이미지 불러오기

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

1. 임시글 목록 불러오기
- 데이터가 없으면 null을 보내도록 수정

2. 메인 페이지 게시글 목록 불러오기
- 최신 탭을 선택하고 목록을 불러 올 때 preiod 변수 관련 오류가 나던 것을 수정.

3. 롤로그 태그 목록 불러오기
- 태그 목록을 불러올 때의 롤로그 소유자가 작성한 총 게시글 수를 가지고 올 수 있도록 수정.
- union을 사용하여, post 테이블에서 총 게시글 수와 post_tag 테이블에서 태그를 사용한 게시글의 수를 가지고 올 수 있도록 하였음.

4. 이미지 불러오기
- nestjs의 serve-static를 이용하여 서버에서 정적 파일을 제공할 수 있도록 수정하였음.
- 기존의 코드는 express모듈을 이용하여 주입하는 것이었음.
<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
