### PR TITLE
fix : series post 반환값 변경

### DIFF
--- a/src/repository/series.repository.ts
+++ b/src/repository/series.repository.ts
@@ -42,9 +42,9 @@ export class SeriesRepository extends Repository<Series> {
         'series.user_id AS user_id',
         'post.id AS post_id',
         'post_series.sort AS sort',
-        'series.thumbnail AS thumbnail',
+        'post.thumbnail AS thumbnail',
         'post.title AS title',
-        'post.content AS content',
+        'post.description AS description',
         'post.create_at AS create_at',
         'IF(series.user_id = :user_id, 1, 0) AS is_owner',
       ])


### PR DESCRIPTION
시리즈의 썸네일이 아닌 게시글의 썸네일 반환
게시글의 context 대신 description 반환

## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- SelectSereisPosts의 반환값 변경

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

thumbnail
- 게시글의 썸네일이 아닌 시리즈의 썸네일으로 되어있어서 게시글 썸네일으로 변경

description
- 게시글의 context가 아닌 description 반환
<br />

## :: 기타 질문 및 특이 사항

- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시)
