### PR TITLE
refactor : 팔로워가 작성한 게시글을 메인에서 처리

### DIFF
--- a/src/main/main.controller.ts
+++ b/src/main/main.controller.ts
@@ -1,5 +1,7 @@
 import { Controller, Get, Query } from '@nestjs/common';
+import { ValidateToken } from 'src/custom-decorator/validate-token.decorator';
 import { SelectMainPostsDto } from 'src/dto/main/select-main-posts.dto';
+import { User } from 'src/entity/user.entity';
 import { MainService } from './main.service';
 
 @Controller('main')
@@ -7,8 +9,8 @@ export class MainController {
   constructor(private readonly mainService: MainService) {}
 
   @Get('')
-  async getMainPosts(@Query() query: SelectMainPostsDto) {
-    const result = await this.mainService.getMainPosts(query);
+  async getMainPosts(@Query() query: SelectMainPostsDto, @ValidateToken() user: User) {
+    const result = await this.mainService.getMainPosts(query, user);
 
     return {
       statusCode: 200,

--- a/src/main/main.model.ts
+++ b/src/main/main.model.ts
@@ -1,6 +1,7 @@
 export enum MainPostsType {
   RECENT = 'recent',
   TREND = 'trend',
+  FOLLOW = 'follow',
 }
 
 export enum PeriodType {

--- a/src/main/main.service.ts
+++ b/src/main/main.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { SelectMainPostsDto } from 'src/dto/main/select-main-posts.dto';
+import { User } from 'src/entity/user.entity';
 import { PostRepository } from 'src/repository/post.repository';
 import { MainPostsType } from './main.model';
 
@@ -7,12 +8,16 @@ import { MainPostsType } from './main.model';
 export class MainService {
   constructor(private postRepository: PostRepository) {}
 
-  async getMainPosts(query: SelectMainPostsDto) {
+  async getMainPosts(query: SelectMainPostsDto, user: User) {
+    if (query.type === 'follow' && !user) {
+      throw new BadRequestException('로그인 한 유저만 팔로우 확인 가능');
+    }
     const posts = await this.postRepository.selectPostListForMain(
       query.type,
       query.period,
       query.offset,
       query.limit,
+      user,
     );
 
     return posts;

--- a/src/repository/post.repository.ts
+++ b/src/repository/post.repository.ts
@@ -191,6 +191,7 @@ export class PostRepository extends Repository<Post> {
     period: PeriodType,
     offset: number,
     limit: number,
+    user: User,
   ) {
     let main_posts = this.createQueryBuilder('post')
       .leftJoin('post.user', 'user')
@@ -239,6 +240,9 @@ export class PostRepository extends Repository<Post> {
         main_posts.groupBy('post.id');
         main_posts.orderBy('SUM(post.likes + post.views)', 'DESC');
         break;
+      case MainPostsType.FOLLOW:
+        main_posts.leftJoin('follow', 'follow', 'post.user_id = follow.followee_id');
+        main_posts.andWhere('follow.follower_id = :user_id', { user_id: user.id });
     }
 
     main_posts.offset(offset * limit - limit);


### PR DESCRIPTION
팔로워가 작성한 게시글을 메인 api에서 처리할 수 있도록 변경

## :: 최근 작업 주제 (하나 이상의 주제를 선택)

- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정)

- 팔로워가 작성한 게시글을 메인에서 확인할 수 있도록 변경

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록)

팔로워가 작성한 게시글을 메인에서 확인할 수 있도록 변경
- 메인 API의 type에 `follow` 추가, ValidateUser으로 로그인한 유저의 경우 유저 정보 가져옴
- 쿼리문에 조건을 추가해서 type이 follow이고 user가 있는 경우에 동작하도록 변경

<br />

## :: 기타 질문 및 특이 사항

